### PR TITLE
Fix name of the Postgres image

### DIFF
--- a/tutorial/docker-compose-postgres.yaml
+++ b/tutorial/docker-compose-postgres.yaml
@@ -15,7 +15,7 @@ services:
     environment:
      - ZOOKEEPER_CONNECT=zookeeper:2181
   postgres:
-    image: debezium/example-postgres:${DEBEZIUM_VERSION}
+    image: debezium/postgres
     ports:
      - 5432:5432
     environment:


### PR DESCRIPTION
The Postgres image specified does not exist. I found https://hub.docker.com/r/debezium/postgres/ and using that works fine, so I assume it's a typo.

That image isn't tagged with a version (other than the Postgres version).