### PR TITLE
Fix connect-jdbc-es folder rename

### DIFF
--- a/unwrap-smt/docker-compose-es.yaml
+++ b/unwrap-smt/docker-compose-es.yaml
@@ -31,7 +31,7 @@ services:
      - transport.host=127.0.0.1
      - xpack.security.enabled=false
   connect:
-    image: debezium/connect-jdbc:${DEBEZIUM_VERSION}
+    image: debezium/connect-jdbc-es:${DEBEZIUM_VERSION}
     build:
       context: debezium-jdbc-es
     ports:

--- a/unwrap-smt/docker-compose-jdbc.yaml
+++ b/unwrap-smt/docker-compose-jdbc.yaml
@@ -31,9 +31,9 @@ services:
      - POSTGRES_PASSWORD=postgrespw
      - POSTGRES_DB=inventory
   connect:
-    image: debezium/connect-jdbc:${DEBEZIUM_VERSION}
+    image: debezium/connect-jdbc-es:${DEBEZIUM_VERSION}
     build:
-      context: debezium-jdbc
+      context: debezium-jdbc-es
     ports:
      - 8083:8083
      - 5005:5005

--- a/unwrap-smt/docker-compose.yaml
+++ b/unwrap-smt/docker-compose.yaml
@@ -39,9 +39,9 @@ services:
      - transport.host=127.0.0.1
      - xpack.security.enabled=false
   connect:
-    image: debezium/connect-jdbc:${DEBEZIUM_VERSION}
+    image: debezium/connect-jdbc-es:${DEBEZIUM_VERSION}
     build:
-      context: debezium-jdbc
+      context: debezium-jdbc-es
     ports:
      - 8083:8083
      - 5005:5005


### PR DESCRIPTION
Current docker-compose files are not working because the `connect-jdbc` folder has been renamed to `connect-jdbc-es`