### PR TITLE
Use Strimzi 0.1.0 release instead of master / latest

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -8,14 +8,14 @@ Prerequisites:
  * [Installed](https://docs.openshift.org/latest/minishift/command-ref/minishift_oc-env.html) OpenShift CLI
 
 ## Debezium Deployment
-Albeit Debezium comes with its own set of images we are going to re-use Kafka broker and Kafka Connect images that are built and delivered by the http://strimzi.io/[Strimzi] project can be used, which offers "Kafka as a Service".
+Albeit Debezium comes with its own set of images we are going to re-use Kafka broker and Kafka Connect images that are built and delivered by the [Strimzi](http://strimzi.io/) project can be used, which offers "Kafka as a Service".
 It consists of enterprise grade configuration files and images that bring Kafka to OpenShift.
 
 First we install the Kafka broker and Kafka Connect templates into our OpenShift project:
 
 ```
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi/master/kafka-statefulsets/resources/openshift-template.yaml
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi/master/kafka-connect/s2i/resources/openshift-template.yaml
+oc create -f https://raw.githubusercontent.com/strimzi/strimzi/0.1.0/kafka-statefulsets/resources/openshift-template.yaml
+oc create -f https://raw.githubusercontent.com/strimzi/strimzi/0.1.0/kafka-connect/s2i/resources/openshift-template.yaml
 ```
 
 Next we will create a Kafka Connect image with deployed Debezium connectors and deploy a Kafka broker cluster and Kafka Connect cluster:

--- a/openshift/debezium/debezium.addon
+++ b/openshift/debezium/debezium.addon
@@ -1,7 +1,7 @@
 # Name: debezium
 # Description: Deploys a Kafka Cluster and a Connect cluster with Debezium
 # Required-Vars: DEBEZIUM_VERSION,DEBEZIUM_PLUGIN,PROJECT,STRIMZI_RELEASE
-# Var-Defaults: STRIMZI_RELEASE=0.1.0,STRIMZI_REPO_NAME=strimzi,STRIMZI_IMAGE_TAG=latest,PROJECT=debezium
+# Var-Defaults: STRIMZI_RELEASE=0.1.0,STRIMZI_REPO_NAME=strimzi,STRIMZI_IMAGE_TAG=0.1.0,PROJECT=debezium
 
 # Pull images
 echo Pulling images...


### PR DESCRIPTION
The examples should not be using files from the Strimzi master branch, which might be changing. It should use the release instead. This PR changes the links to the files from master to the 0.1.0 release. It also changes the tag for Docker images from `latest` to 0.1.0 and fixes the link to Strimzi website.