### PR TITLE
Exploration of aggregate materialization with JPA

### DIFF
--- a/jpa-aggregations/README.md
+++ b/jpa-aggregations/README.md
@@ -1,0 +1,48 @@
+# Debezium Hibernate Aggregate Materialization Demo
+
+This demo shows how to materialize consistent aggregates (e.g. a customer and all their addresses) using a PoC-level Hibernate ORM extension.
+This extension persists materialized aggregates (represented as JSON) in a dedicated table, `aggregates`.
+Debezium is set up to capture changes from this table and stream them into Kafka.
+An SMT (single message transform) is used to expand the aggregate's JSON into typed Kafka Connect records and route them into a dedicated topic per aggregate root type.
+The Elasticsearch sink connector is used to consume these records and persist the structured aggregate into Elasticsearch.
+
+## Usage
+
+How to run:
+
+```shell
+# Start the DB, Kafka Connect, Elasticsearch etc.
+export DEBEZIUM_VERSION=0.9
+docker-compose up --build
+
+# Register MySQL connector to capture changes from the "aggregates" table
+curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @source.json
+```
+
+Import the _jpa-test_ project into your IDE and execute `JpaAggregationTest`.
+
+```shell
+# Observe changes to the aggregate topic while applying more changes to customers using the test class above
+docker-compose exec kafka /kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server kafka:9092 \
+    --from-beginning \
+    --property print.key=true \
+    --topic customers-complete
+```
+
+```shell
+# Register ES sink connector
+curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @es-sink-aggregates.json
+```
+
+Examine contents of the Elasticsearch index while you alter the customer data:
+
+```shell
+curl -i -X GET -H "Accept:application/json" http://localhost:9200/customers-complete/_search?pretty
+```
+End the application:
+
+```shell
+# Shut down the cluster
+docker-compose down
+```

--- a/jpa-aggregations/docker-compose.yaml
+++ b/jpa-aggregations/docker-compose.yaml
@@ -15,7 +15,9 @@ services:
     environment:
      - ZOOKEEPER_CONNECT=zookeeper:2181
   mysql:
-    image: debezium/example-mysql:${DEBEZIUM_VERSION}
+    image: debezium/jpa-aggregation-example-db:${DEBEZIUM_VERSION}
+    build:
+      context: example-db
     ports:
      - 3306:3306
     environment:
@@ -32,9 +34,9 @@ services:
      - xpack.security.enabled=false
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
   connect:
-    image: debezium/connect-jdbc-es:${DEBEZIUM_VERSION}
+    image: debezium/connect-json-smt-es:${DEBEZIUM_VERSION}
     build:
-      context: debezium-jdbc-es
+      context: json-smt-es
     ports:
      - 8083:8083
      - 5005:5005
@@ -47,3 +49,5 @@ services:
      - GROUP_ID=1
      - CONFIG_STORAGE_TOPIC=my_connect_configs
      - OFFSET_STORAGE_TOPIC=my_connect_offsets
+     - KAFKA_DEBUG=true
+     - DEBUG_SUSPEND_FLAG=n

--- a/jpa-aggregations/es-sink-aggregates.json
+++ b/jpa-aggregations/es-sink-aggregates.json
@@ -1,0 +1,16 @@
+{
+    "name": "es-customers",
+    "config": {
+        "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+        "tasks.max": "1",
+        "topics": "customers-complete",
+        "connection.url": "http://elastic:9200",
+        "key.ignore": "false",
+        "schema.ignore" : "false",
+        "behavior.on.null.values" : "delete",
+        "type.name": "customer-with-addresses",
+        "transforms" : "key",
+        "transforms.key.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
+        "transforms.key.field": "id"
+    }
+}

--- a/jpa-aggregations/example-db/Dockerfile
+++ b/jpa-aggregations/example-db/Dockerfile
@@ -1,0 +1,3 @@
+FROM debezium/example-mysql:0.9
+
+COPY schema-update.sql /docker-entrypoint-initdb.d/

--- a/jpa-aggregations/example-db/schema-update.sql
+++ b/jpa-aggregations/example-db/schema-update.sql
@@ -1,0 +1,50 @@
+# Switch to this database
+USE inventory;
+
+CREATE TABLE categories (
+  id INTEGER NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+INSERT INTO categories VALUES (1000001, 'Premium');
+
+ALTER TABLE customers ADD some_blob BLOB;
+ALTER TABLE customers ADD isactive BOOLEAN;
+ALTER TABLE customers ADD category_id INTEGER;
+ALTER TABLE customers ADD birthday DATE;
+ALTER TABLE customers ADD CONSTRAINT fk_customer_category_id FOREIGN KEY (category_id) REFERENCES inventory.categories(id);
+
+UPDATE customers SET isactive = 1;
+UPDATE customers SET category_id = 1000001 WHERE id = 1001;
+UPDATE customers SET birthday = '1978-5-31' WHERE id = 1001;
+
+CREATE TABLE customer_scores (
+  customer_id INTEGER NOT NULL,
+  idx TINYINT NOT NULL,
+  score DECIMAL(4,2) NOT NULL,
+  PRIMARY KEY (customer_id, score)
+);
+
+CREATE TABLE customer_tags (
+  customer_id INTEGER NOT NULL,
+  idx TINYINT NOT NULL,
+  tag VARCHAR(255) NOT NULL,
+  PRIMARY KEY (customer_id, tag)
+);
+
+INSERT INTO customer_scores VALUES (1001, 0, 8.9);
+INSERT INTO customer_scores VALUES (1001, 1, 42.0);
+
+INSERT INTO customer_tags VALUES (1001, 0, 'foo');
+INSERT INTO customer_tags VALUES (1001, 1, 'bar');
+INSERT INTO customer_tags VALUES (1001, 2, 'qux');
+
+CREATE TABLE aggregates (
+  rootId VARCHAR(2000) NOT NULL,
+  rootType VARCHAR(255) NOT NULL,
+  keySchema LONGTEXT,
+  valueSchema LONGTEXT,
+  materialization LONGTEXT,
+  PRIMARY KEY (rootId, rootType)
+);

--- a/jpa-aggregations/jpa-test/pom.xml
+++ b/jpa-aggregations/jpa-test/pom.xml
@@ -1,0 +1,97 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.debezium.examples.aggregation</groupId>
+	<artifactId>aggregation-test</artifactId>
+	<version>1.0.0.Final</version>
+	<name>Hibernate ORM 5 Test Case Template</name>
+
+	<properties>
+		<version.com.h2database>1.3.176</version.com.h2database>
+		<version.junit>4.12</version.junit>
+		<version.org.hibernate>5.3.3.Final</version.org.hibernate>
+		<version.org.slf4j>1.7.2</version.org.slf4j>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-testing</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.12</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-jsonSchema</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.9.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>connect-json</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${version.junit}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${version.org.slf4j}</version>
+		</dependency>
+
+		<!-- Not necessary for ORM 5.2 and above -->
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-java8</artifactId>
+			<version>${version.org.hibernate}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectArraySchemaSerializer.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectArraySchemaSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.connect;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectArraySchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectObjectSchemaAdapter;
+
+public class KafkaConnectArraySchemaSerializer extends StdSerializer<KafkaConnectArraySchemaAdapter> {
+
+	        public KafkaConnectArraySchemaSerializer() {
+	            this(null);
+	        }
+
+	        public KafkaConnectArraySchemaSerializer(Class<KafkaConnectArraySchemaAdapter> t) {
+	            super(t);
+	        }
+
+	        @Override
+	        public void serialize(KafkaConnectArraySchemaAdapter value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+	            gen.writeStartObject();
+	            gen.writeStringField("type", value.getConnectType());
+
+	            if (!value.isByteArray()) {
+	                gen.writeFieldName("items");
+	                if (value.getConnectItems() instanceof KafkaConnectObjectSchemaAdapter) {
+	                    KafkaConnectObjectSchemaSerializer itemSerializer = new KafkaConnectObjectSchemaSerializer(false);
+	                    itemSerializer.serialize((KafkaConnectObjectSchemaAdapter) value.getConnectItems(), gen, provider);
+	                }
+	                else {
+	                    KafkaConnectSchemaSerializer itemSerializer = new KafkaConnectSchemaSerializer();
+	                    itemSerializer.serialize(value.getConnectItems(), gen, provider);
+	                }
+	            }
+
+
+	            gen.writeBooleanField("optional", value.isOptional());
+	            gen.writeStringField("field", value.getField());
+
+	            gen.writeEndObject();
+	        }
+
+	        @Override
+	        public void serializeWithType(KafkaConnectArraySchemaAdapter value, JsonGenerator gen, SerializerProvider serializers,
+	                TypeSerializer typeSer) throws IOException {
+	            serialize(value, gen, serializers);
+	        }
+	    }

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectObjectSchemaSerializer.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectObjectSchemaSerializer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.connect;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectArraySchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectObjectSchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectSchemaAdapter;
+
+public class KafkaConnectObjectSchemaSerializer extends StdSerializer<KafkaConnectObjectSchemaAdapter> {
+
+        private boolean isRoot;
+
+        public KafkaConnectObjectSchemaSerializer() {
+            this(true);
+        }
+
+        public KafkaConnectObjectSchemaSerializer(boolean isRoot) {
+            this(null);
+            this.isRoot = isRoot;
+        }
+
+        public KafkaConnectObjectSchemaSerializer(Class<KafkaConnectObjectSchemaAdapter> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(KafkaConnectObjectSchemaAdapter value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+
+            if (isRoot) {
+                gen.writeObjectFieldStart("schema");
+            }
+
+            gen.writeStringField("type", value.getConnectType());
+            gen.writeArrayFieldStart("fields");
+
+            for (KafkaConnectSchemaAdapter propertySchema : value.getFields()) {
+                if (propertySchema instanceof KafkaConnectObjectSchemaAdapter) {
+                    KafkaConnectObjectSchemaSerializer itemSerializer = new KafkaConnectObjectSchemaSerializer(false);
+                    itemSerializer.serialize((KafkaConnectObjectSchemaAdapter) propertySchema, gen, provider);
+                }
+                else if (propertySchema instanceof KafkaConnectArraySchemaAdapter) {
+                    KafkaConnectArraySchemaSerializer itemSerializer = new KafkaConnectArraySchemaSerializer();
+                    itemSerializer.serialize((KafkaConnectArraySchemaAdapter) propertySchema, gen, provider);
+                }
+                else {
+                    KafkaConnectSchemaSerializer itemSerializer = new KafkaConnectSchemaSerializer();
+                    itemSerializer.serialize(propertySchema, gen, provider);
+                }
+
+            }
+
+            gen.writeEndArray();
+            gen.writeBooleanField("optional", value.isOptional());
+            gen.writeStringField("name", value.getName());
+
+            if (isRoot) {
+                gen.writeEndObject();
+            }
+            else if (value.getField() != null) {
+                gen.writeStringField("field", value.getField());
+            }
+
+            gen.writeEndObject();
+        }
+
+        @Override
+        public void serializeWithType(KafkaConnectObjectSchemaAdapter value, JsonGenerator gen, SerializerProvider serializers,
+                TypeSerializer typeSer) throws IOException {
+            serialize(value, gen, serializers);
+        }
+    }
+

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectSchemaFactoryWrapper.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectSchemaFactoryWrapper.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.connect;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.factories.JsonSchemaFactory;
+import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
+import com.fasterxml.jackson.module.jsonSchema.factories.VisitorContext;
+import com.fasterxml.jackson.module.jsonSchema.factories.WrapperFactory;
+import com.fasterxml.jackson.module.jsonSchema.types.AnySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ArraySchema;
+import com.fasterxml.jackson.module.jsonSchema.types.BooleanSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.IntegerSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.NumberSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.StringSchema;
+
+/**
+ * Emits Kafka Connect's JSON schema format instead of regular JSON Schema.
+ *
+ * @author Gunnar Morling
+ */
+public class KafkaConnectSchemaFactoryWrapper extends SchemaFactoryWrapper {
+
+    private static class KafkaConnectSchemaFactoryWrapperFactory extends WrapperFactory {
+        @Override
+        public SchemaFactoryWrapper getWrapper(SerializerProvider p) {
+            SchemaFactoryWrapper wrapper = new KafkaConnectSchemaFactoryWrapper();
+            if (p != null) {
+                wrapper.setProvider(p);
+            }
+            return wrapper;
+        };
+
+        @Override
+        public SchemaFactoryWrapper getWrapper(SerializerProvider p, VisitorContext rvc) {
+            SchemaFactoryWrapper wrapper = new KafkaConnectSchemaFactoryWrapper();
+            if (p != null) {
+                wrapper.setProvider(p);
+            }
+            wrapper.setVisitorContext(rvc);
+            return wrapper;
+        }
+    };
+
+    public KafkaConnectSchemaFactoryWrapper() {
+        super(new KafkaConnectSchemaFactoryWrapperFactory());
+        schemaProvider = new KafkaConnectSchemaAdapterFactory();
+    }
+
+    public interface KafkaConnectSchemaAdapter {
+        String getConnectType();
+
+        boolean isOptional();
+
+        String getField();
+
+        String getName();
+    }
+
+    public static class KafkaConnectObjectSchemaAdapter extends ObjectSchema implements KafkaConnectSchemaAdapter {
+
+        private String field;
+
+        @Override
+        public String getConnectType() {
+            return "struct";
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+        }
+
+        public KafkaConnectSchemaAdapter[] getFields() {
+            return getProperties().values().toArray(new KafkaConnectSchemaAdapter[0]);
+        }
+
+        @Override
+        public String getName() {
+            return getId();
+        }
+    }
+
+    public static class KafkaConnectArraySchemaAdapter extends ArraySchema implements KafkaConnectSchemaAdapter {
+
+        private String field;
+        private boolean isByteArray;
+
+        @Override
+        public String getConnectType() {
+            return isByteArray ? "bytes" : "array";
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+
+            if (beanProperty.getType().isArrayType()) {
+                if (beanProperty.getType().getContentType().getRawClass() == byte.class) {
+                    isByteArray = true;
+                } else {
+                    getItems().asSingleItems().getSchema().enrichWithBeanProperty(beanProperty);
+                }
+            }
+        }
+
+        public KafkaConnectSchemaAdapter getConnectItems() {
+            if (getItems().isSingleItems()) {
+                return (KafkaConnectSchemaAdapter) getItems().asSingleItems().getSchema();
+            } else {
+                throw new UnsupportedOperationException("Mixed array item types are disallowed");
+            }
+        }
+
+        @Override
+        public String getName() {
+            return getId();
+        }
+
+        public boolean isByteArray() {
+            return isByteArray;
+        }
+
+        @Override
+        public void setItemsSchema(JsonSchema jsonSchema) {
+            if (jsonSchema instanceof NumberSchema) {
+                super.setItemsSchema(new KafkaConnectNumberSchemaAdapter());
+            } else if (jsonSchema instanceof IntegerSchema) {
+                super.setItemsSchema(new KafkaConnectIntegerSchemaAdapter());
+            } else if (jsonSchema instanceof StringSchema) {
+                super.setItemsSchema(new KafkaConnectStringSchemaAdapter());
+            } else if (jsonSchema instanceof BooleanSchema) {
+                super.setItemsSchema(new KafkaConnectBooleanSchemaAdapter());
+            } else {
+                super.setItemsSchema(jsonSchema);
+            }
+        }
+    }
+
+    public static class KafkaConnectIntegerSchemaAdapter extends IntegerSchema implements KafkaConnectSchemaAdapter {
+
+        private String connectType;
+        private String field;
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+
+            if (beanProperty.getType().getRawClass() == byte.class
+                    || beanProperty.getType().getRawClass() == Byte.class) {
+                connectType = "int8";
+            } else if (beanProperty.getType().getRawClass() == short.class
+                    || beanProperty.getType().getRawClass() == Short.class) {
+                connectType = "int16";
+            } else if (beanProperty.getType().getRawClass() == int.class
+                    || beanProperty.getType().getRawClass() == Integer.class) {
+                connectType = "int32";
+            } else if (beanProperty.getType().getRawClass() == long.class
+                    || beanProperty.getType().getRawClass() == Long.class) {
+                connectType = "int64";
+            } else {
+                throw new UnsupportedOperationException("Property of unsupported integer type: " + beanProperty);
+            }
+        }
+
+        @Override
+        public String getConnectType() {
+            return connectType;
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    public static class KafkaConnectNumberSchemaAdapter extends NumberSchema implements KafkaConnectSchemaAdapter {
+
+        private String connectType;
+        private String field;
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+
+            if (beanProperty.getType().getRawClass() == float.class
+                    || beanProperty.getType().getRawClass() == Float.class
+                    || beanProperty.getType().getRawClass() == float[].class
+                    || beanProperty.getType().getRawClass() == Float[].class) {
+                connectType = "float";
+            } else if (beanProperty.getType().getRawClass() == double.class
+                    || beanProperty.getType().getRawClass() == Double.class
+                    || beanProperty.getType().getRawClass() == double[].class
+                    || beanProperty.getType().getRawClass() == Double[].class) {
+                connectType = "double";
+            }
+            // TODO BigDecimal -> Decimal via custom annotation for specifying scale
+            else {
+                throw new UnsupportedOperationException("Property of unsupported numeric type: " + beanProperty);
+            }
+        }
+
+        @Override
+        public String getConnectType() {
+            return connectType;
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    public static class KafkaConnectStringSchemaAdapter extends StringSchema implements KafkaConnectSchemaAdapter {
+
+        private String field;
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+        }
+
+        @Override
+        public String getConnectType() {
+            return "string";
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    public static class KafkaConnectBooleanSchemaAdapter extends BooleanSchema implements KafkaConnectSchemaAdapter {
+
+        private String field;
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+        }
+
+        @Override
+        public String getConnectType() {
+            return "boolean";
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    public static class KafkaConnectAnySchemaAdapter extends AnySchema implements KafkaConnectSchemaAdapter {
+
+        private String connectType;
+        private String field;
+        private String name;
+
+        @Override
+        public void enrichWithBeanProperty(BeanProperty beanProperty) {
+            field = beanProperty.getName();
+
+            if (beanProperty.getType().getRawClass() == LocalDate.class) {
+                connectType = "int32";
+                name = "io.debezium.time.Timestamp";
+            }
+            else {
+                throw new UnsupportedOperationException("Property of unsupported type: " + beanProperty);
+            }
+        }
+
+        @Override
+        public String getConnectType() {
+            return connectType;
+        }
+
+        @Override
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean isOptional() {
+            return !Boolean.TRUE.equals(getRequired());
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class KafkaConnectSchemaAdapterFactory extends JsonSchemaFactory {
+
+        @Override
+        public BooleanSchema booleanSchema() {
+            return new KafkaConnectBooleanSchemaAdapter();
+        }
+
+        @Override
+        public StringSchema stringSchema() {
+            return new KafkaConnectStringSchemaAdapter();
+        }
+
+        @Override
+        public IntegerSchema integerSchema() {
+            return new KafkaConnectIntegerSchemaAdapter();
+        }
+
+        @Override
+        public NumberSchema numberSchema() {
+            return new KafkaConnectNumberSchemaAdapter();
+        }
+
+        @Override
+        public ObjectSchema objectSchema() {
+            return new KafkaConnectObjectSchemaAdapter();
+        }
+
+        @Override
+        public ArraySchema arraySchema() {
+            return new KafkaConnectArraySchemaAdapter();
+        }
+
+        @Override
+        public AnySchema anySchema() {
+            return new KafkaConnectAnySchemaAdapter();
+        }
+    }
+}

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectSchemaSerializer.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/connect/KafkaConnectSchemaSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.connect;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectSchemaAdapter;
+
+public class KafkaConnectSchemaSerializer extends StdSerializer<KafkaConnectSchemaAdapter> {
+
+	    public KafkaConnectSchemaSerializer() {
+	        this(null);
+	    }
+
+	    public KafkaConnectSchemaSerializer(Class<KafkaConnectSchemaAdapter> t) {
+	        super(t);
+	    }
+
+        @Override
+        public void serialize(KafkaConnectSchemaAdapter value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeStartObject();
+            gen.writeStringField("type", value.getConnectType());
+            gen.writeBooleanField("optional", value.isOptional());
+            if (value.getField() != null) {
+                gen.writeStringField("field", value.getField());
+            }
+            if (value.getName() != null) {
+                gen.writeStringField("name", value.getName());
+                gen.writeNumberField("version", 1);
+            }
+            gen.writeEndObject();
+        }
+
+        @Override
+        public void serializeWithType(KafkaConnectSchemaAdapter value, JsonGenerator gen, SerializerProvider serializers,
+                TypeSerializer typeSer) throws IOException {
+            serialize(value, gen, serializers);
+        }
+	}
+

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/Aggregate.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/Aggregate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.hibernate;
+
+import java.io.Serializable;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "aggregates")
+public class Aggregate {
+
+    @EmbeddedId
+    public AggregateKey pk;
+
+    public String keySchema;
+
+    public String valueSchema;
+
+    public String materialization;
+
+    @Embeddable
+    public static class AggregateKey implements Serializable {
+
+        public String rootId;
+
+        public String rootType;
+
+        public AggregateKey() {
+        }
+
+        public AggregateKey(String rootId, String rootType) {
+            this.rootId = rootId;
+            this.rootType = rootType;
+        }
+
+        @Override
+        public String toString() {
+            return "AggregateKey [rootId=" + rootId + ", rootType=" + rootType + "]";
+        }
+    }
+}

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/AggregationBuilderIntegrator.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/AggregationBuilderIntegrator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.hibernate;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+
+/**
+ * Integrator for Hibernate ORM that enables aggregate materialization via {@link MaterializeAggregate}.
+ *
+ * @author Gunnar Morling
+ */
+public class AggregationBuilderIntegrator implements Integrator {
+
+    @Override
+    public void integrate(Metadata metadata, SessionFactoryImplementor sessionFactory,
+            SessionFactoryServiceRegistry serviceRegistry) {
+
+        EventListenerRegistry eventListenerRegistry = serviceRegistry.getService(EventListenerRegistry.class);
+
+        AggregationBuilderListener listener = new AggregationBuilderListener();
+
+        eventListenerRegistry.appendListeners(EventType.POST_INSERT, listener);
+        eventListenerRegistry.appendListeners(EventType.POST_UPDATE, listener);
+        eventListenerRegistry.appendListeners(EventType.POST_DELETE, listener);
+    }
+
+    @Override
+    public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+    }
+}

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/AggregationBuilderListener.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/AggregationBuilderListener.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.hibernate;
+
+import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+
+import com.example.domain.Customer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.types.ObjectSchema;
+
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectSchemaAdapterFactory;
+import io.debezium.aggregation.hibernate.Aggregate.AggregateKey;
+
+/**
+ * Hibernate event listener that materializes aggregates for given entities via JSON into a separate table.
+ *
+ * @author Gunnar Morling
+ */
+class AggregationBuilderListener implements PostInsertEventListener, PostUpdateEventListener, PostDeleteEventListener {
+
+        private final ObjectMapper mapper;
+
+        public AggregationBuilderListener() {
+            mapper = new ObjectMapperFactory().buildObjectMapper();
+        }
+
+        @Override
+        public boolean requiresPostCommitHanding(EntityPersister persister) {
+            return false;
+        }
+
+        @Override
+        public void onPostInsert(PostInsertEvent event) {
+            String aggregateName = getAggregateName((event.getPersister().getMappedClass()));
+            if (aggregateName != null) {
+                insertOrUpdateAggregate(
+                        event.getEntity(),
+                        event.getId(),
+                        event.getPersister().getIdentifierPropertyName(),
+                        aggregateName,
+                        event.getSession()
+                );
+            }
+        }
+
+        @Override
+        public void onPostUpdate(PostUpdateEvent event) {
+            String aggregateName = getAggregateName((event.getPersister().getMappedClass()));
+            if (aggregateName != null) {
+                insertOrUpdateAggregate(
+                        event.getEntity(),
+                        event.getId(),
+                        event.getPersister().getIdentifierPropertyName(),
+                        aggregateName,
+                        event.getSession()
+                );
+            }
+        }
+
+        @Override
+        public void onPostDelete(PostDeleteEvent event) {
+            String aggregateName = getAggregateName((event.getPersister().getMappedClass()));
+            if (aggregateName != null) {
+                deleteAggregate(
+                        event.getEntity(),
+                        event.getId(),
+                        event.getPersister().getIdentifierPropertyName(),
+                        aggregateName,
+                        event.getSession()
+                );
+            }
+        }
+
+        private String getAggregateName(Class<?> entityType) {
+            MaterializeAggregate materializeAggregate = entityType.getAnnotation(MaterializeAggregate.class);
+            return materializeAggregate != null ? materializeAggregate.aggregateName() : null;
+        }
+
+        private void insertOrUpdateAggregate(Object entity, Object id, String idProperty, String aggregateName, EventSource session) {
+            session.getActionQueue().registerProcess( new BeforeTransactionCompletionProcess() {
+
+                @Override
+                public void doBeforeTransactionCompletion(SessionImplementor session) {
+                    if ( !session.getTransactionCoordinator().isActive() ) {
+                        return;
+                    }
+
+                    try {
+                        KafkaConnectSchemaFactoryWrapper visitor = new KafkaConnectSchemaFactoryWrapper();
+                        mapper.acceptJsonFormatVisitor(Customer.class, visitor);
+                        String materialization = mapper.writeValueAsString(entity);
+                        JsonSchema valueSchema = visitor.finalSchema();
+
+                        String idString = "{ \"" + idProperty + "\" : " + mapper.writeValueAsString(id) + " }";
+                        ObjectSchema keySchema = new KafkaConnectSchemaAdapterFactory().objectSchema();
+                        keySchema.putProperty(idProperty, valueSchema.asObjectSchema().getProperties().get(idProperty));
+                        keySchema.setId(aggregateName + ".Key");
+                        keySchema.setRequired(true);
+
+                        Aggregate aggregate = new Aggregate();
+                        aggregate.pk = new AggregateKey(idString, aggregateName);
+                        aggregate.keySchema = mapper.writeValueAsString(keySchema);
+                        aggregate.materialization = materialization;
+                        aggregate.valueSchema = mapper.writeValueAsString(valueSchema);
+
+//                        Session temporarySession = null;
+//                        try {
+//                            temporarySession = session.sessionWithOptions()
+//                                    .connection()
+//                                    .autoClose( false )
+//                                    .connectionHandlingMode( PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION )
+//                                    .openSession();
+//                            temporarySession.saveOrUpdate(aggregate);
+//                            temporarySession.flush();
+//                        }
+//                        finally {
+//                            if ( temporarySession != null ) {
+//                                temporarySession.close();
+//                            }
+//                        }
+
+                        session.saveOrUpdate(aggregate);
+                        session.flush();
+                    }
+                    catch(RuntimeException e) {
+                        throw e;
+                    }
+                    catch(Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } );
+        }
+
+        private void deleteAggregate(Object entity, Object id, String idProperty, String aggregateName, EventSource session) {
+            session.getActionQueue().registerProcess( new BeforeTransactionCompletionProcess() {
+
+                @Override
+                public void doBeforeTransactionCompletion(SessionImplementor session) {
+                    if ( !session.getTransactionCoordinator().isActive() ) {
+                        return;
+                    }
+
+                    try {
+//                        Session temporarySession = null;
+//                        try {
+//                            temporarySession = session.sessionWithOptions()
+//                                    .connection()
+//                                    .autoClose( false )
+//                                    .connectionHandlingMode( PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION )
+//                                    .openSession();
+//                            temporarySession.saveOrUpdate(aggregate);
+//                            temporarySession.flush();
+//                        }
+//                        finally {
+//                            if ( temporarySession != null ) {
+//                                temporarySession.close();
+//                            }
+//                        }
+
+                        String idString = "{ \"" + idProperty + "\" : " + mapper.writeValueAsString(id) + " }";
+                        Aggregate aggregate = session.getReference(Aggregate.class, new AggregateKey(idString, aggregateName));
+                        session.delete(aggregate);
+                        session.flush();
+                    }
+                    catch(RuntimeException e) {
+                        throw e;
+                    }
+                    catch(Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            } );
+        }
+    }

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/MaterializeAggregate.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/MaterializeAggregate.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.hibernate;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MaterializeAggregate {
+    String aggregateName();
+}

--- a/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/ObjectMapperFactory.java
+++ b/jpa-aggregations/jpa-test/src/main/java/io/debezium/aggregation/hibernate/ObjectMapperFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.hibernate;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.debezium.aggregation.connect.KafkaConnectArraySchemaSerializer;
+import io.debezium.aggregation.connect.KafkaConnectObjectSchemaSerializer;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectArraySchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectObjectSchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper.KafkaConnectSchemaAdapter;
+import io.debezium.aggregation.connect.KafkaConnectSchemaSerializer;
+
+public class ObjectMapperFactory {
+
+    public ObjectMapper buildObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(KafkaConnectSchemaAdapter.class, new KafkaConnectSchemaSerializer());
+        module.addSerializer(KafkaConnectObjectSchemaAdapter.class, new KafkaConnectObjectSchemaSerializer());
+        module.addSerializer(KafkaConnectArraySchemaAdapter.class, new KafkaConnectArraySchemaSerializer());
+        module.addSerializer(LocalDate.class, new LocalDateAsEpochDaysSerializer());
+        mapper.registerModule(module);
+
+        return mapper;
+    }
+
+    private static class LocalDateAsEpochDaysSerializer extends JsonSerializer<LocalDate> {
+
+        @Override
+        public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeNumber(value.toEpochDay());
+        }
+    }
+}

--- a/jpa-aggregations/jpa-test/src/main/resources/META-INF/persistence.xml
+++ b/jpa-aggregations/jpa-test/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,49 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+	version="2.1">
+
+	<persistence-unit name="templatePU" transaction-type="RESOURCE_LOCAL">
+
+		<description>Hibernate test case template Persistence Unit</description>
+		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+		<class>com.example.domain.Customer</class>
+		<class>com.example.domain.Category</class>
+		<class>com.example.domain.Address</class>
+		<exclude-unlisted-classes>false</exclude-unlisted-classes>
+
+		<properties>
+			<property name="hibernate.archive.autodetection" value="class, hbm" />
+
+			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
+			<property name="hibernate.connection.driver_class" value="com.mysql.cj.jdbc.Driver" />
+			<property name="hibernate.connection.url" value="jdbc:mysql://localhost:3306/inventory" />
+			<property name="hibernate.connection.username" value="mysqluser" />
+			<property name="hibernate.connection.password" value="mysqlpw" />
+
+			<property name="hibernate.connection.pool_size" value="5" />
+
+			<property name="hibernate.show_sql" value="true" />
+			<property name="hibernate.format_sql" value="true" />
+			<!-- <property name="hibernate.hbm2ddl.auto" value="create-drop"/> -->
+			<property name="hibernate.hbm2ddl.auto" value="none" />
+
+			<property name="hibernate.max_fetch_depth" value="5" />
+
+			<property name="hibernate.cache.region_prefix" value="hibernate.test" />
+			<property name="hibernate.cache.region.factory_class"
+				value="org.hibernate.testing.cache.CachingRegionFactory" />
+
+			<!--NOTE: hibernate.jdbc.batch_versioned_data should be set to false when 
+				testing with Oracle -->
+			<property name="hibernate.jdbc.batch_versioned_data" value="true" />
+
+			<property name="javax.persistence.validation.mode" value="NONE" />
+			<property name="hibernate.service.allow_crawling" value="false" />
+			<property name="hibernate.session.events.log" value="true" />
+		</properties>
+
+	</persistence-unit>
+</persistence>

--- a/jpa-aggregations/jpa-test/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/jpa-aggregations/jpa-test/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,1 @@
+io.debezium.aggregation.hibernate.AggregationBuilderIntegrator

--- a/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Address.java
+++ b/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Address.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.example.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Entity
+@Table(name = "addresses")
+public class Address {
+
+    @Id
+    public long id;
+
+    @ManyToOne
+    @JoinColumn(name = "customer_id")
+    @JsonIgnore
+    public Customer customer;
+
+    public String street;
+
+    public String city;
+
+    public String state;
+
+    public String zip;
+
+    @Enumerated(EnumType.STRING)
+    public AddressType type;
+
+    @Override
+    public String toString() {
+        return "Address [id=" + id + ", street=" + street + ", city=" + city + ", state=" + state + ", zip=" + zip
+                + ", type=" + type + "]";
+    }
+}

--- a/jpa-aggregations/jpa-test/src/test/java/com/example/domain/AddressType.java
+++ b/jpa-aggregations/jpa-test/src/test/java/com/example/domain/AddressType.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.example.domain;
+
+public enum AddressType {
+    SHIPPING,
+    BILLING,
+    LIVING;
+}

--- a/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Category.java
+++ b/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Category.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.example.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "categories")
+public class Category {
+
+    @Id
+    public long id;
+
+    public String name;
+}

--- a/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Customer.java
+++ b/jpa-aggregations/jpa-test/src/test/java/com/example/domain/Customer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.example.domain;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.Table;
+
+import io.debezium.aggregation.hibernate.MaterializeAggregate;
+
+@Entity
+@Table(name = "customers")
+@MaterializeAggregate(aggregateName="customers-complete")
+public class Customer {
+
+    @Id
+    public long id;
+
+    @Column(name = "first_name")
+    public String firstName;
+
+    @Column(name = "last_name")
+    public String lastName;
+
+    public String email;
+
+    @Column(name = "some_blob")
+    public byte[] someBlob;
+
+    @Column(name = "isactive")
+    public boolean active;
+
+    @ElementCollection
+    @CollectionTable(
+          name="customer_scores",
+          joinColumns=@JoinColumn(name="customer_id")
+    )
+    @Column(name="score")
+    @OrderColumn(name="idx")
+    public double[] scores;
+
+    @ElementCollection
+    @CollectionTable(
+          name="customer_tags",
+          joinColumns=@JoinColumn(name="customer_id")
+    )
+    @Column(name="tag")
+    @OrderColumn(name="idx")
+    public String[] tags;
+
+    public LocalDate birthday;
+
+    @ManyToOne
+    public Category category;
+
+    @OneToMany(mappedBy = "customer", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    public Set<Address> addresses;
+
+    @Override
+    public String toString() {
+        return "Customer [id=" + id + ", firstName=" + firstName + ", lastName=" + lastName + ", email=" + email
+                + ", addresses=" + addresses + "]";
+    }
+}

--- a/jpa-aggregations/jpa-test/src/test/java/io/debezium/example/jpaaggregation/test/JpaAggregationTest.java
+++ b/jpa-aggregations/jpa-test/src/test/java/io/debezium/example/jpaaggregation/test/JpaAggregationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.example.jpaaggregation.test;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.example.domain.Category;
+import com.example.domain.Customer;
+
+/**
+ * Simple test for creating a customer aggregate.
+ */
+public class JpaAggregationTest {
+
+    private EntityManagerFactory entityManagerFactory;
+
+    @Before
+    public void init() {
+        entityManagerFactory = Persistence.createEntityManagerFactory("templatePU");
+    }
+
+    @After
+    public void destroy() {
+        entityManagerFactory.close();
+    }
+
+    @Test
+    public void createCustomerAggregate() throws Exception {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        entityManager.getTransaction().begin();
+
+        entityManager.createQuery("update Customer c set c.active = false where c.id = 1004").executeUpdate();
+        Customer sally = entityManager.find(Customer.class, 1004L);
+//
+        sally.active = true;
+        sally.firstName = "Sally Deluxe 123";
+        Category category = new Category();
+        category.id = 100001L;
+        category.name = "Retail";
+        entityManager.persist(category);
+
+        sally.category = category;
+//        sally.someBlob = "some text".getBytes();
+//
+//
+//
+//        entityManager.merge(sally);
+
+        entityManager.getTransaction().commit();
+        entityManager.close();
+    }
+}

--- a/jpa-aggregations/jpa-test/src/test/java/io/debezium/example/jpaaggregation/test/SerializerTest.java
+++ b/jpa-aggregations/jpa-test/src/test/java/io/debezium/example/jpaaggregation/test/SerializerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.example.jpaaggregation.test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.HashMap;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.junit.Test;
+
+import com.example.domain.Customer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+
+import io.debezium.aggregation.connect.KafkaConnectSchemaFactoryWrapper;
+import io.debezium.aggregation.hibernate.ObjectMapperFactory;
+
+public class SerializerTest {
+
+    @Test
+    public void simpleJsonSerialization() throws Exception {
+        Customer c = new Customer();
+        c.someBlob = new byte[] {1,2,3};
+        c.scores = new double[] {8.9, 42.0};
+        c.tags = new String[] { "foo", "bar" };
+        c.birthday = LocalDate.of(1978, Month.APRIL, 12);
+
+        ObjectMapper mapper = new ObjectMapperFactory().buildObjectMapper();
+
+        System.out.println(mapper.writeValueAsString(c));
+    }
+
+	@Test
+	public void connectSchemaExample() throws Exception {
+	    Schema schema = SchemaBuilder.struct()
+	        .field("mystring", SchemaBuilder.STRING_SCHEMA)
+	        .field("myarr", SchemaBuilder.array(SchemaBuilder.INT64_SCHEMA))
+	        .field("mybytearr", SchemaBuilder.bytes())
+	        .field("category", SchemaBuilder.struct().name("Category").field("id", SchemaBuilder.INT64_SCHEMA))
+	        .build();
+
+	    JsonConverter jsonConverter = new JsonConverter();
+	    HashMap<String, Object> configs = new HashMap<>();
+	    configs.put("converter.type", "value");
+        jsonConverter.configure(configs);
+        ObjectNode node = jsonConverter.asJsonSchema(schema);
+	    System.out.println(node);
+	}
+
+	@Test
+	public void simpleSchemaSerialization() throws Exception {
+	    ObjectMapper mapper = new ObjectMapperFactory().buildObjectMapper();
+
+	    KafkaConnectSchemaFactoryWrapper visitor = new KafkaConnectSchemaFactoryWrapper();
+        mapper.acceptJsonFormatVisitor(Customer.class, visitor);
+        JsonSchema schema1 = visitor.finalSchema();
+        String schema = mapper.writeValueAsString(schema1);
+
+        JsonConverter jsonConverter = new JsonConverter();
+        HashMap<String, Object> configs = new HashMap<>();
+        configs.put("converter.type", "value");
+        jsonConverter.configure(configs);
+        String envelope = "{ "
+                    + schema.substring(2, schema.length() -2) + ","
+                    + " \"payload\" : { "
+                        + "\"id\" : 1001, "
+                        + "\"firstName\" : \"Bob\", "
+                        + "\"lastName\" : \"Smith\", "
+                        + "\"email\" : \"mail@example.com\", "
+                        + "\"active\" : true, "
+                        + "\"someBlob\" : \"U29tZSBiaW5hcnkgYmxvYg==\", "
+                        + "\"addresses\" : {}, "
+                        + "\"scores\" : [ 8.9, 42.0 ], "
+                        + "\"tags\" : [ \"foo\", \"bar\" ], "
+                        + "\"category\" : {"
+                            + "\"id\" : 123,"
+                            + "\"name\" : \"B2B\""
+                        + "},"
+                        + "\"birthday\" : 3023"
+                    + "} "
+                + "}";
+
+        System.out.println(envelope);
+
+        SchemaAndValue sav = jsonConverter.toConnectData("dummy", envelope.getBytes());
+
+        System.out.println(sav);
+	}
+}

--- a/jpa-aggregations/jpa-test/src/test/resources/log4j.properties
+++ b/jpa-aggregations/jpa-test/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=DEBUG, stdout
+ 
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/jpa-aggregations/json-smt-es/Dockerfile
+++ b/jpa-aggregations/json-smt-es/Dockerfile
@@ -1,14 +1,9 @@
 FROM debezium/connect:0.9
-ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc \
+ENV KAFKA_CONNECT_JSON_SMT_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-json-smt \
     KAFKA_CONNECT_ES_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-elasticsearch
 
-
-# Deploy PostgreSQL JDBC Driver
-RUN cd /kafka/libs && curl -sO https://jdbc.postgresql.org/download/postgresql-42.1.4.jar
-
-# Deploy Kafka Connect JDBC
-RUN mkdir $KAFKA_CONNECT_JDBC_DIR && cd $KAFKA_CONNECT_JDBC_DIR &&\
-	curl -sO http://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/5.0.0/kafka-connect-jdbc-5.0.0.jar
+RUN mkdir $KAFKA_CONNECT_JSON_SMT_DIR
+COPY target/json-smt-1.0.0.Final.jar $KAFKA_CONNECT_JSON_SMT_DIR
 
 # Deploy Confluent Elasticsearch sink connector
 RUN mkdir $KAFKA_CONNECT_ES_DIR && cd $KAFKA_CONNECT_ES_DIR &&\

--- a/jpa-aggregations/json-smt-es/pom.xml
+++ b/jpa-aggregations/json-smt-es/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>io.debezium.examples.aggregation</groupId>
+	<artifactId>json-smt</artifactId>
+	<version>1.0.0.Final</version>
+	<name>SMT for expanding an incoming JSON field into a typed SourceRecord</name>
+
+	<properties>
+	</properties>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jpa-aggregations/json-smt-es/src/main/java/io/debezium/aggregation/smt/ExpandJsonSmt.java
+++ b/jpa-aggregations/json-smt-es/src/main/java/io/debezium/aggregation/smt/ExpandJsonSmt.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.aggregation.smt;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.transforms.Transformation;
+
+/**
+ * Takes Kafka Connect schema and JSON payload from a message and expands it into a properly typed record.
+ *
+ * @author Gunnar Morling
+ *
+ * @param <R>
+ */
+public class ExpandJsonSmt<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private JsonConverter converter;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        Map<String, String> config = new HashMap<>();
+        config.put("converter.type", "value");
+        // config.put("schemas.enable", "false");
+
+        converter = new JsonConverter();
+        converter.configure(config);
+    }
+
+    @Override
+    public R apply(R record) {
+        // we're only interested in actual CDC records not schema change events
+        if (record.valueSchema() == null || !record.valueSchema().name().endsWith(".Envelope")) {
+            return record;
+        }
+
+        Struct struct = (Struct) record.value();
+        String op = struct.getString("op");
+
+        if (op.equals("r") || op.equals("c") || op.equals("u")) {
+            Struct after = struct.getStruct("after");
+            Object id = after.get("rootId");
+            String rootType = after.getString("rootType");
+            String keySchema = after.getString("keySchema");
+            String valueSchema = after.getString("valueSchema");
+            String materialization = after.getString("materialization");
+
+            String valueEnvelope = "{ " + valueSchema.substring(2, valueSchema.length() - 2) + ", \"payload\" : " + materialization
+                    + "}";
+
+            SchemaAndValue value = converter.toConnectData("dummy", valueEnvelope.getBytes());
+
+            String keyEnvelope = "{ " + keySchema.substring(2, keySchema.length() - 2) + ", \"payload\" : " + id
+                    + "}";
+
+            SchemaAndValue key = converter.toConnectData("dummy", keyEnvelope.getBytes());
+
+            return record.newRecord(rootType, record.kafkaPartition(), key.schema(), key.value(), value.schema(),
+                    value.value(), record.timestamp());
+        }
+        else if (op.equals("d")) {
+            Struct before = struct.getStruct("before");
+            Object id = before.get("rootId");
+            String rootType = before.getString("rootType");
+            String keySchema = before.getString("keySchema");
+
+            String keyEnvelope = "{ " + keySchema.substring(2, keySchema.length() - 2) + ", \"payload\" : " + id
+                    + "}";
+
+            SchemaAndValue key = converter.toConnectData("dummy", keyEnvelope.getBytes());
+
+            return record.newRecord(rootType, record.kafkaPartition(), key.schema(), key.value(), null, null,
+                    record.timestamp());
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected record type: " + record);
+        }
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public void close() {
+        converter.close();
+    }
+}

--- a/jpa-aggregations/source.json
+++ b/jpa-aggregations/source.json
@@ -1,0 +1,19 @@
+{
+    "name": "inventory-connector",
+    "config": {
+        "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+        "tasks.max": "1",
+        "database.hostname": "mysql",
+        "database.port": "3306",
+        "database.user": "debezium",
+        "database.password": "dbz",
+        "database.server.id": "184054",
+        "database.server.name": "dbserver1",
+        "database.whitelist": "inventory",
+        "table.whitelist": ".*aggregates",
+        "database.history.kafka.bootstrap.servers": "kafka:9092",
+        "database.history.kafka.topic": "schema-changes.inventory",
+        "transforms" : "expandjson",
+        "transforms.expandjson.type": "io.debezium.aggregation.smt.ExpandJsonSmt"
+    }
+}

--- a/unwrap-smt/es-sink-aggregates.json
+++ b/unwrap-smt/es-sink-aggregates.json
@@ -1,0 +1,15 @@
+{
+    "name": "elastic-sink-aggregates",
+    "config": {
+        "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+        "tasks.max": "1",
+        "topics": "aggregates",
+        "connection.url": "http://elastic:9200",
+        "transforms": "unwrap,key",
+        "transforms.unwrap.type": "io.debezium.transforms.UnwrapFromEnvelope",
+        "transforms.key.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
+        "transforms.key.field": "rootId",
+        "key.ignore": "false",
+        "type.name": "customer-with-addresses"
+    }
+}


### PR DESCRIPTION
*Update:* @jpechane, the PR is cleaned up much more now, also the README provides some basic instructions. So you could give it a try and let me know what you think :)

Hey @jpechane, here's what I've been up to these past days.

The idea is to materialize aggregates (say a customer and their addresses) within a dedicated table in the source DB and within the upstream TX. DBZ then is used to only CDC this single table, and a new SMT is used to convert the aggregates (which have been persisted as JSON) into properly typed Kafka Connect records which then can be sinked e.g. using the Elasticsearch sink connector or @hpgrahsl's MongoDB connector.

It's still very rough, but the main parts are working. To try it out, do this (the README still is not up to date):

* Build the SMT: mvn clean install -f json-smt-es/pom.xml
* docker-compose up --build
* curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @source.json
* Import the _jpa-test_ project into your IDE and run `JpaAggregationTest`; this updates a customer, causing the materialization of an aggregate of the customer and all associated records in other tables
* Examine the aggregate on the console: docker-compose exec kafka /kafka/bin/kafka-console-consumer.sh \
    --bootstrap-server kafka:9092 \
    --from-beginning \
    --property print.key=true \
    --topic customers-complete
* Sink aggregate into ES: curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @es-sink-aggregates.json
* curl -X GET -H "Accept:application/json" http://localhost:9200/customers-complete/_search?pretty

On the JPA side, I've built a small Hibernate extension which evaluates the `@MaterializeAggregate` annotation (see `Customer`) and creates a JSON representation of the annotated entity (using Jackson). The most challenging part was to have Jackson emit Kafka Connect Schema instead of regular JSON Schema. That's vital though to not loose type info (e.g. correct numeric types over JSON's very limited native types).

I'll polish and improve going forward, any feedback is more than welcome. Let me know if you're trying to run it and have any issues. As said, still need to clean up and provide more detailed instructions :)