### PR TITLE
Modifications to make kstreams tutorial operational out-of-the-box

### DIFF
--- a/kstreams/debezium-mongodb/Dockerfile
+++ b/kstreams/debezium-mongodb/Dockerfile
@@ -2,12 +2,7 @@ FROM debezium/connect:0.8
 ENV KAFKA_CONNECT_MONGODB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-mongodb
 
 USER root
-RUN yum -y install git maven curl && yum clean all
-
-RUN cd /kafka/libs && \
-  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongodb-driver/3.8.2/mongodb-driver-3.8.2.jar --remote-name && \
-  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongodb-driver-core/3.8.2/mongodb-driver-core-3.8.2.jar --remote-name && \
-  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/bson/3.8.2/bson-3.8.2.jar --remote-name
+RUN yum -y install git maven && yum clean all
 
 USER kafka
 
@@ -15,6 +10,8 @@ USER kafka
 RUN mkdir -p $KAFKA_CONNECT_MONGODB_DIR && cd $KAFKA_CONNECT_MONGODB_DIR && \
   git clone https://github.com/hpgrahsl/kafka-connect-mongodb.git && \
   cd kafka-connect-mongodb && \
+  git fetch --tags && \
+  git checkout tags/v1.2.0 && \
   mvn clean package -DskipTests=true -DskipITs=true && \
-  mv target/kafka-connect-mongodb-1.2.0.jar $KAFKA_CONNECT_MONGODB_DIR && \
+  mv target/kafka-connect-mongodb/kafka-connect-mongodb-1.2.0-jar-with-dependencies.jar $KAFKA_CONNECT_MONGODB_DIR && \
   cd .. && rm -rf $KAFKA_CONNECT_MONGODB_DIR/kafka-connect-mongodb

--- a/kstreams/debezium-mongodb/Dockerfile
+++ b/kstreams/debezium-mongodb/Dockerfile
@@ -2,14 +2,19 @@ FROM debezium/connect:0.8
 ENV KAFKA_CONNECT_MONGODB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-mongodb
 
 USER root
-RUN yum -y install git maven && yum clean all
+RUN yum -y install git maven curl && yum clean all
+
+RUN cd /kafka/libs && \
+  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongodb-driver/3.8.2/mongodb-driver-3.8.2.jar --remote-name && \
+  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/mongodb-driver-core/3.8.2/mongodb-driver-core-3.8.2.jar --remote-name && \
+  curl -s https://oss.sonatype.org/content/repositories/releases/org/mongodb/bson/3.8.2/bson-3.8.2.jar --remote-name
 
 USER kafka
 
 # Deploy MongoDB Sink Connector
-RUN mkdir $KAFKA_CONNECT_MONGODB_DIR && cd $KAFKA_CONNECT_MONGODB_DIR && \
+RUN mkdir -p $KAFKA_CONNECT_MONGODB_DIR && cd $KAFKA_CONNECT_MONGODB_DIR && \
   git clone https://github.com/hpgrahsl/kafka-connect-mongodb.git && \
   cd kafka-connect-mongodb && \
   mvn clean package -DskipTests=true -DskipITs=true && \
-  mv target/kafka-connect-mongodb-1.1.0-SNAPSHOT-jar-with-dependencies.jar $KAFKA_CONNECT_MONGODB_DIR && \
+  mv target/kafka-connect-mongodb-1.2.0.jar $KAFKA_CONNECT_MONGODB_DIR && \
   cd .. && rm -rf $KAFKA_CONNECT_MONGODB_DIR/kafka-connect-mongodb


### PR DESCRIPTION
Hey, hope this PR finds you well. I was tinkering with the kstreams / ddd aggregate tutorial and noticed a few issues with it out of the box. 

The first issue I ran into, was this:
```bash
mv: cannot stat 'target/kafka-connect-mongodb-1.1.0-SNAPSHOT-jar-with-dependencies.jar': No such file or directory
```

Upon some introspection I found that the target was looking for `mongodb-1.2.0`, so I modified it accordingly and got past that error. 

(I also added the `-p` flag to the `mkdir` since it barfed my second time through the build that the directory existed.)

Secondly, when the build was complete after the above mods, and all of the containers had come up, I was able to add my MySQL connector, but was _not_ able to add my MongoDB sink connector.

I found it throwing 500's when I post the sink configuration over, after looking at the container logs and seeing this...
```bash
connect_sink_1    | javax.servlet.ServletException: org.glassfish.jersey.server.ContainerException: java.lang.BootstrapMethodError: java.lang.NoClassDefFoundError: com/mongodb/MongoClientURI
```

I added curl to the container dependencies, and grabbed mongo drivers & bson.

If there's a better way to do this part, let me know! Java isn't my first language, but I can put those dependencies where they need to be with curl for sure. ;)

Anyway - with these commits, the kstreams tutorial will be back to working right out of the box just by following the README. I'd love to have feedback on a better (more java native) way to do the jar deps if you guys have one. If not, I happily offer this PR to get the community back on track with the tutorial!

Cheers!
Dustin