### PR TITLE
Use simple cache for known transactions

### DIFF
--- a/cache-invalidation/src/main/java/io/debezium/examples/cacheinvalidation/persistence/KnownTransactions.java
+++ b/cache-invalidation/src/main/java/io/debezium/examples/cacheinvalidation/persistence/KnownTransactions.java
@@ -28,6 +28,7 @@ public class KnownTransactions {
         cacheManager.defineConfiguration(
                 "tx-id-cache",
                 new ConfigurationBuilder()
+                    .simpleCache(true)
                     .expiration()
                         .lifespan(60, TimeUnit.SECONDS)
                     .build()


### PR DESCRIPTION
Minor change to use simple cache for known transactions.

@gunnarmorling Infinispan caches within EAP are designed for internal use only, hence you're not supposed to create one there and use it for Debezium. The approach taken in the examples is right, you manage your own cache manager and caches.

Btw, I was unable to test example. After calling `mvn clean package` and `docker-compose up --build`, I tried to place an order but got an internal server error with WildFly showing:

```
order-manager_1  | Caused by: java.lang.NullPointerException
order-manager_1  | 	at io.debezium.examples.cacheinvalidation.rest.OrderResource.addOrder(OrderResource.java:35)
```

The rest of the stacktrace is [here](https://gist.github.com/galderz/c39ee57a2c003cb50d5cdaf1dd806dd3). Looking at the rest of the Wildfly log, the only thing I've noticed is [this message](https://gist.github.com/galderz/75049cd19b7908189e5ddd64c7da6c2b).