### PR TITLE
fix kstream example aggregator script

### DIFF
--- a/kstreams/poc-ddd-aggregates/run-aggregator.sh
+++ b/kstreams/poc-ddd-aggregates/run-aggregator.sh
@@ -4,4 +4,4 @@ export PATH="/opt/poc-ddd-aggregates/jdk/bin:${PATH}"
 export JAVA_APP_DIR=/opt/poc-ddd-aggregates/lib
 export JAVA_MAIN_CLASS=io.debezium.examples.aggregation.StreamingAggregatesDDD
 
-exec  /opt/poc-ddd-aggregates/run-java.sh "$PARENT_TOPIC $CHILDREN_TOPIC $BOOTSTRAP_SERVERS"
+exec /opt/poc-ddd-aggregates/run-java.sh "$PARENT_TOPIC" "$CHILDREN_TOPIC" "$BOOTSTRAP_SERVERS"


### PR DESCRIPTION
Hey,

I just tried to start the `kstreams` example, but ran into the following error;

```
exec java -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:+ExitOnOutOfMemoryError -cp .:/opt/poc-ddd-aggregates/lib/* io.debezium.examples.aggregation.StreamingAggregatesDDD dbserver1.inventory.customers dbserver1.inventory.addresses kafka:9092
usage: java -jar <package> io.debezium.examples.aggregation.StreamingAggregatesDDD <parent_topic> <children_topic> <bootstrap_servers>
```

I was able to fix it by using separate quotation for each parameter.