### PR TITLE
DBZ-2059: update README.md with correct docker-compose-mysql-avro file

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -80,7 +80,7 @@ a new version of that schema will be available in the registry.
 The service registry also comes with a console consumer that can read the Avro messages:
 
 ```shell
-docker-compose -f docker-compose-mysql-avro.yaml exec schema-registry /usr/bin/kafka-avro-console-consumer \
+docker-compose -f docker-compose-mysql-avro-worker.yaml exec schema-registry /usr/bin/kafka-avro-console-consumer \
     --bootstrap-server kafka:9092 \
     --from-beginning \
     --property print.key=true \


### PR DESCRIPTION
There is a small error in the [README documentation](https://github.com/debezium/debezium-examples/blob/master/tutorial/README.md#using-mysql-and-the-avro-message-format)

The `docker-compose-mysql-avro.yaml` is missing instead we should use `docker-compose-mysql-avro-worker.yaml` or `docker-compose-mysql-avro-connector.yaml `

For this particular case doesn't matter so I've decided to use the first one