### PR TITLE
[auditlog] Upgrading to current version of Debezium and Quarkus;

### DIFF
--- a/auditlog/README.md
+++ b/auditlog/README.md
@@ -33,7 +33,7 @@ $ http PUT http://localhost:8083/connectors/inventory-connector/config < registe
 ## Modifying Some Data and Observing the Audit Log
 
 ```console
-$ http POST http://localhost:8080/vegetables 'Authorization: Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJib2IiLCJ1cG4iOiJmYXJtZXJib2IiLCJhdXRoX3RpbWUiOjE1NjY0NTgxMTMsImlzcyI6ImZhcm1zaG9wIiwiZ3JvdXBzIjpbImZhcm1lcnMiLCJjdXN0b21lcnMiXSwiZXhwIjo0MTAyNDQ0Nzk5LCJpYXQiOjE1NjY0NTgxMTMsImp0aSI6IjQyIn0.CscbJN8amqKryYvnVO1184J8F67HN2iTEjVN2VOPodcnoeOd7_iQVKUjC3h-ye5apkJjvAsQKrjzlrGCHRfl-n6jC9F7IkOtjoWnJ4wQ9BBo1SAtPw_Czt1I_Ujm-Kb1p5-BWACCBCVVFgYZTWP_laz5JZS7dIvs6VqoNnw7A4VpA6iPfTVfYlNY3u86-k1FvEg_hW-N9Y9RuihMsPuTdpHK5xdjCrJiD0VJ7-0eRQ8RXpycHuHN4xfmV8MqXBYjYSYDOhbnYbdQVbf0YJoFFqfb75my5olN-97ITsi2MS62W_y-RNT0qZrbytqINA3fF3VQsSY6VcaqRAeygrKm_Q' 'Date: Thu, 22 Aug 2019 08:12:31 GMT' name=Tomatoe description=Yummy!
+$ http POST http://localhost:8080/vegetables 'Authorization:Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJib2IiLCJ1cG4iOiJmYXJtZXJib2IiLCJhdXRoX3RpbWUiOjE1NjY0NTgxMTMsImlzcyI6ImZhcm1zaG9wIiwiZ3JvdXBzIjpbImZhcm1lcnMiLCJjdXN0b21lcnMiXSwiZXhwIjo0MTAyNDQ0Nzk5LCJpYXQiOjE1NjY0NTgxMTMsImp0aSI6IjQyIn0.CscbJN8amqKryYvnVO1184J8F67HN2iTEjVN2VOPodcnoeOd7_iQVKUjC3h-ye5apkJjvAsQKrjzlrGCHRfl-n6jC9F7IkOtjoWnJ4wQ9BBo1SAtPw_Czt1I_Ujm-Kb1p5-BWACCBCVVFgYZTWP_laz5JZS7dIvs6VqoNnw7A4VpA6iPfTVfYlNY3u86-k1FvEg_hW-N9Y9RuihMsPuTdpHK5xdjCrJiD0VJ7-0eRQ8RXpycHuHN4xfmV8MqXBYjYSYDOhbnYbdQVbf0YJoFFqfb75my5olN-97ITsi2MS62W_y-RNT0qZrbytqINA3fF3VQsSY6VcaqRAeygrKm_Q' 'Date:Thu, 22 Aug 2019 08:12:31 GMT' name=Tomatoe description=Yummy!
 ```
 
 This uses a pre-generated JWT token (with expiration date set to 2099-12-31 and user set to "farmerbob").
@@ -42,13 +42,13 @@ To regenerate the token with different data, use the [Jwtenizr](https://github.c
 You can also update an existing vegetable record (this token is for "farmermargaret"):
 
 ```console
-$ http PUT http://localhost:8080/vegetables/10 'Authorization: Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJtYXJnYXJldCIsInVwbiI6ImZhcm1lcm1hcmdhcmV0IiwiYXV0aF90aW1lIjoxNTY5ODM1Mzk5LCJpc3MiOiJmYXJtc2hvcCIsImdyb3VwcyI6WyJmYXJtZXJzIiwiY3VzdG9tZXJzIl0sImV4cCI6NDEwMjQ0NDc5OSwiaWF0IjoxNTY5ODM1Mzk5LCJqdGkiOiI0MiJ9.DTEUA3p-xyK5nveoJIVhjfKNFdVszYIb55Qj4Xrm70DDbAXuOU2FMkffuUAUm2s7ACkp2KEmg6brRwSjvA-zhW61kDR9ZgEb9NWeDjr6Eue08xcSODKt7SGV-M7h3yhuDIhU7uaZrxRUAQTWqm1vxd2rmN_QH0frhKMUNFFsLIOGLG0zHcLosRcwZ4tAKXSSB9VE0fth6srIQCUebDkF7ucA_WSYjPRvahCBd8JvnV4VUGQxZW8zcRhTEwcaLq20ODO-dr85xgWI2Yr_1A7PDuDL4oUjCb90YyhtzaIzs2vQMjcxJ6TWmTcqJpgCfkjE-TeVwjaafcNJu0fBmcP8jA' 'Date: Thu, 22 Aug 2019 08:12:31 GMT' name=Tomatoe description=Tasty!
+$ http PUT http://localhost:8080/vegetables/10 'Authorization:Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJtYXJnYXJldCIsInVwbiI6ImZhcm1lcm1hcmdhcmV0IiwiYXV0aF90aW1lIjoxNTY5ODM1Mzk5LCJpc3MiOiJmYXJtc2hvcCIsImdyb3VwcyI6WyJmYXJtZXJzIiwiY3VzdG9tZXJzIl0sImV4cCI6NDEwMjQ0NDc5OSwiaWF0IjoxNTY5ODM1Mzk5LCJqdGkiOiI0MiJ9.DTEUA3p-xyK5nveoJIVhjfKNFdVszYIb55Qj4Xrm70DDbAXuOU2FMkffuUAUm2s7ACkp2KEmg6brRwSjvA-zhW61kDR9ZgEb9NWeDjr6Eue08xcSODKt7SGV-M7h3yhuDIhU7uaZrxRUAQTWqm1vxd2rmN_QH0frhKMUNFFsLIOGLG0zHcLosRcwZ4tAKXSSB9VE0fth6srIQCUebDkF7ucA_WSYjPRvahCBd8JvnV4VUGQxZW8zcRhTEwcaLq20ODO-dr85xgWI2Yr_1A7PDuDL4oUjCb90YyhtzaIzs2vQMjcxJ6TWmTcqJpgCfkjE-TeVwjaafcNJu0fBmcP8jA' 'Date:Thu, 22 Aug 2019 08:12:31 GMT' name=Tomatoe description=Tasty!
 ```
 
 Or delete a record (again using the "farmerbob" token):
 
 ```console
-$ http DELETE http://localhost:8080/vegetables/10 'Authorization: Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJib2IiLCJ1cG4iOiJmYXJtZXJib2IiLCJhdXRoX3RpbWUiOjE1NjY0NTgxMTMsImlzcyI6ImZhcm1zaG9wIiwiZ3JvdXBzIjpbImZhcm1lcnMiLCJjdXN0b21lcnMiXSwiZXhwIjo0MTAyNDQ0Nzk5LCJpYXQiOjE1NjY0NTgxMTMsImp0aSI6IjQyIn0.CscbJN8amqKryYvnVO1184J8F67HN2iTEjVN2VOPodcnoeOd7_iQVKUjC3h-ye5apkJjvAsQKrjzlrGCHRfl-n6jC9F7IkOtjoWnJ4wQ9BBo1SAtPw_Czt1I_Ujm-Kb1p5-BWACCBCVVFgYZTWP_laz5JZS7dIvs6VqoNnw7A4VpA6iPfTVfYlNY3u86-k1FvEg_hW-N9Y9RuihMsPuTdpHK5xdjCrJiD0VJ7-0eRQ8RXpycHuHN4xfmV8MqXBYjYSYDOhbnYbdQVbf0YJoFFqfb75my5olN-97ITsi2MS62W_y-RNT0qZrbytqINA3fF3VQsSY6VcaqRAeygrKm_Q' 'Date: Thu, 22 Aug 2019 08:12:31 GMT'
+$ http DELETE http://localhost:8080/vegetables/10 'Authorization:Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJib2IiLCJ1cG4iOiJmYXJtZXJib2IiLCJhdXRoX3RpbWUiOjE1NjY0NTgxMTMsImlzcyI6ImZhcm1zaG9wIiwiZ3JvdXBzIjpbImZhcm1lcnMiLCJjdXN0b21lcnMiXSwiZXhwIjo0MTAyNDQ0Nzk5LCJpYXQiOjE1NjY0NTgxMTMsImp0aSI6IjQyIn0.CscbJN8amqKryYvnVO1184J8F67HN2iTEjVN2VOPodcnoeOd7_iQVKUjC3h-ye5apkJjvAsQKrjzlrGCHRfl-n6jC9F7IkOtjoWnJ4wQ9BBo1SAtPw_Czt1I_Ujm-Kb1p5-BWACCBCVVFgYZTWP_laz5JZS7dIvs6VqoNnw7A4VpA6iPfTVfYlNY3u86-k1FvEg_hW-N9Y9RuihMsPuTdpHK5xdjCrJiD0VJ7-0eRQ8RXpycHuHN4xfmV8MqXBYjYSYDOhbnYbdQVbf0YJoFFqfb75my5olN-97ITsi2MS62W_y-RNT0qZrbytqINA3fF3VQsSY6VcaqRAeygrKm_Q' 'Date:Thu, 22 Aug 2019 08:12:31 GMT'
 ```
 
 Doing so, observe the contents of the `dbserver1.inventory.vegetable`, `dbserver1.inventory.transaction_context_data` and `dbserver1.inventory.vegetable.enriched` topics:
@@ -56,19 +56,19 @@ Doing so, observe the contents of the `dbserver1.inventory.vegetable`, `dbserver
 ```console
 $ docker run -it --rm \
     --network auditlog_default \
-    debezium/tooling:1.0 \
+    debezium/tooling:1.1 \
     /bin/bash -c "kafkacat -b kafka:9092 \
     -C -o beginning -q -u -t dbserver1.inventory.vegetable | jq ."
 
 $ docker run -it --rm \
     --network auditlog_default \
-    debezium/tooling:1.0 \
+    debezium/tooling:1.1 \
     /bin/bash -c "kafkacat -b kafka:9092 \
     -C -o beginning -q -u -t dbserver1.inventory.transaction_context_data | jq ."
 
 $ docker run -it --rm \
     --network auditlog_default \
-    debezium/tooling:1.0 \
+    debezium/tooling:1.1 \
     /bin/bash -c "kafkacat -b kafka:9092 \
     -C -o beginning -q -u -t dbserver1.inventory.vegetable.enriched | jq ."
 ```
@@ -103,7 +103,7 @@ create a task for administrator to provide the missing data.
 ```console
 $ docker run --tty --rm -i \
         --network auditlog_default \
-        debezium/tooling:1.0 \
+        debezium/tooling:1.1 \
         bash -c 'pgcli postgresql://postgresuser:postgrespw@vegetables-db:5432/vegetablesdb'
 ```
 

--- a/auditlog/admin-service/pom.xml
+++ b/auditlog/admin-service/pom.xml
@@ -6,18 +6,18 @@
   <artifactId>auditing-admin-service</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>0.25.0</quarkus.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <quarkus.version>1.4.2.Final</quarkus.version>
+    <surefire-plugin.version>2.22.0</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
+        <artifactId>quarkus-universe-bom</artifactId>
         <version>${quarkus.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -26,8 +26,8 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kogito</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionEvent.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionEvent.java
@@ -3,63 +3,73 @@ package io.debezium.demos.auditing.admin;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TransactionEvent {
-        
-    private TransactionData before;    
-    private TransactionData after;    
+
+    private TransactionData before;
+    private TransactionData after;
     private SourceData source;
     @JsonProperty("op")
     private String operation;
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("ts_ms")
     private Date timestamp;
-    
+
+    @JsonIgnore
+    private String transaction;
+
     public TransactionData getBefore() {
         return before;
     }
-    
+
     public void setBefore(TransactionData before) {
         this.before = before;
     }
-    
+
     public TransactionData getAfter() {
         return after;
     }
-    
+
     public void setAfter(TransactionData after) {
         this.after = after;
     }
-    
+
     public SourceData getSource() {
         return source;
     }
-    
+
     public void setSource(SourceData source) {
         this.source = source;
     }
-    
+
     public String getOperation() {
         return operation;
     }
-    
+
     public void setOperation(String operation) {
         this.operation = operation;
     }
-    
+
     public Date getTimestamp() {
         return timestamp;
     }
-    
+
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public String getTransaction() {
+        return transaction;
+    }
+
+    public void setTransaction(String transaction) {
+        this.transaction = transaction;
     }
 
     @Override
     public String toString() {
         return "TransactionEvent [before=" + before + ", after=" + after + ", source=" + source + ", operation=" + operation + ", timestamp=" + timestamp + "]";
     }
-    
-    
 }

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableEvent.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableEvent.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class VegetableEvent {
-    
+
     private VegetableData before;
     private VegetableData after;
     private SourceData source;
@@ -16,6 +16,9 @@ public class VegetableEvent {
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("ts_ms")
     private Date timestamp;
+
+    @JsonIgnore
+    private String transaction;
 
     @JsonIgnore
     private boolean matched;
@@ -66,6 +69,14 @@ public class VegetableEvent {
 
     public void setMatched(boolean matched) {
         this.matched = matched;
+    }
+
+    public String getTransaction() {
+        return transaction;
+    }
+
+    public void setTransaction(String transaction) {
+        this.transaction = transaction;
     }
 
     @Override

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/wih/SendTransactionEventWIHandler.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/wih/SendTransactionEventWIHandler.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -14,43 +16,41 @@ import io.debezium.demos.auditing.admin.AuditData;
 import io.debezium.demos.auditing.admin.TransactionData;
 import io.debezium.demos.auditing.admin.TransactionEvent;
 import io.debezium.demos.auditing.admin.VegetableEvent;
-import io.smallrye.reactive.messaging.annotations.Channel;
-import io.smallrye.reactive.messaging.annotations.Emitter;
-import io.smallrye.reactive.messaging.kafka.KafkaMessage;
+import io.smallrye.reactive.messaging.kafka.KafkaRecord;
 
 @ApplicationScoped
 public class SendTransactionEventWIHandler implements WorkItemHandler {
 
     private ObjectMapper json = new ObjectMapper();
-    
+
     @Channel("missingtransactions")
-    Emitter<KafkaMessage<String, String>> emitter;
-    
+    Emitter<String> emitter;
+
     @Override
     public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
         try {
             VegetableEvent vegetable = (VegetableEvent) workItem.getParameter("vegetable");
             AuditData audit = (AuditData) workItem.getParameter("audit");
-            
+
             TransactionEvent event = new TransactionEvent();
-    
+
             event.setSource(vegetable.getSource());
             event.setOperation(vegetable.getOperation());
             event.setTimestamp(new java.util.Date());
-    
+
             TransactionData data = new TransactionData();
             data.setTransactionId(vegetable.getSource().getTransactionId());
             data.setUseCase(audit.getUseCase());
             data.setClientDate(new java.util.Date());
             data.setUsername(audit.getUsername());
-    
+
             event.setAfter(data);
-    
+
             String key = json.writeValueAsString(Collections.singletonMap("transaction_id", vegetable.getSource().getTransactionId()));
             String value = json.writeValueAsString(event);
-            
-            emitter.send(KafkaMessage.of(key, value));
-            
+
+            emitter.send(KafkaRecord.of(key, value));
+
             manager.completeWorkItem(workItem.getId(), null);
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -59,13 +59,11 @@ public class SendTransactionEventWIHandler implements WorkItemHandler {
 
     @Override
     public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
-       
+
     }
 
     @Override
     public String getName() {
         return "Send Task";
     }
-
-    
 }

--- a/auditlog/log-enricher/pom.xml
+++ b/auditlog/log-enricher/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>0.25.0</quarkus.version>
+    <quarkus.version>1.4.2.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/auditlog/vegetables-service/pom.xml
+++ b/auditlog/vegetables-service/pom.xml
@@ -8,7 +8,7 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>0.25.0</quarkus.version>
+    <quarkus.version>1.4.2.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
* Kafka Streams 2.3 brought an incompatability around state stores, hence the change to TimestampedKeyValueStore (see https://kafka.apache.org/23/documentation/streams/upgrade-guide#streams_api_changes_230)
* The Kogito admin service needed updating to ignore the new "transaction" field and use latest MP Reactive Messaging APIs

@Naros, could you check out this one? Note there's still one issue with the admin service, it currently fails to send the TX metadata events to Kafka. I'm discussing with @cescoffier why that is.

@cescoffier, here's the stacktrace:

```
admin-service_1       | Caused by: java.lang.ClassCastException: io.smallrye.reactive.messaging.kafka.OutgoingKafkaRecord cannot be cast to java.lang.String
admin-service_1       | 	at org.apache.kafka.common.serialization.StringSerializer.serialize(StringSerializer.java:28)
admin-service_1       | 	at org.apache.kafka.common.serialization.Serializer.serialize(Serializer.java:62)
admin-service_1       | 	at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:903)
admin-service_1       | 	at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:865)
admin-service_1       | 	at io.vertx.kafka.client.producer.impl.KafkaWriteStreamImpl.lambda$send$4(KafkaWriteStreamImpl.java:93)
admin-service_1       | 	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
admin-service_1       | 	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
admin-service_1       | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
admin-service_1       | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
admin-service_1       | 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
admin-service_1       | 	at java.lang.Thread.run(Thread.java:748)
```

The outgoing channel is defined as

```
mp.messaging.outgoing.missingtransactions.topic=dbserver1.inventory.transaction_context_data
mp.messaging.outgoing.missingtransactions.key.serializer=org.apache.kafka.common.serialization.StringSerializer
mp.messaging.outgoing.missingtransactions.value.serializer=org.apache.kafka.common.serialization.StringSerializer
```

It's used via `@Channel("missingtransactions") Emitter<KafkaRecord<String, String>> emitter;` in the application. It's unclear to me why the `OutgoingKafkaRecord` itself is passed to the serializer instead of the key/value.