### PR TITLE
DBZ-2083 fix tutorial for Apicurio converter

### DIFF
--- a/tutorial/debezium-with-apicurio/Dockerfile
+++ b/tutorial/debezium-with-apicurio/Dockerfile
@@ -1,7 +1,0 @@
-ARG DEBEZIUM_VERSION
-FROM debezium/connect:$DEBEZIUM_VERSION
-ENV KAFKA_CONNECT_DEBEZIUM_DIR=$KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-mysql
-ENV APICURIO_VERSION=1.2.2.Final
-
-RUN cd $KAFKA_CONNECT_DEBEZIUM_DIR &&\
-    curl https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/$APICURIO_VERSION/apicurio-registry-distro-connect-converter-$APICURIO_VERSION-converter.tar.gz | tar xzv

--- a/tutorial/docker-compose-mysql-apicurio.yaml
+++ b/tutorial/docker-compose-mysql-apicurio.yaml
@@ -27,11 +27,7 @@ services:
     ports:
      - 8080:8080
   connect:
-    image: debezium/debezium-with-apicurio:${DEBEZIUM_VERSION}
-    build:
-      context: debezium-with-apicurio
-      args:
-        DEBEZIUM_VERSION: ${DEBEZIUM_VERSION}
+    image: debezium/connect:${DEBEZIUM_VERSION}
     ports:
      - 8083:8083
     links:
@@ -44,5 +40,6 @@ services:
      - CONFIG_STORAGE_TOPIC=my_connect_configs
      - OFFSET_STORAGE_TOPIC=my_connect_offsets
      - STATUS_STORAGE_TOPIC=my_connect_statuses
+     - ENABLE_APICURIO_CONVERTERS=true
      - INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter
      - INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter

--- a/tutorial/register-mysql-apicurio-converter-avro.json
+++ b/tutorial/register-mysql-apicurio-converter-avro.json
@@ -14,9 +14,9 @@
         "database.history.kafka.topic": "schema-changes.inventory",
         "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
         "key.converter.apicurio.registry.url": "http://apicurio:8080/api",
-        "key.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy",
+        "key.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
         "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
         "value.converter.apicurio.registry.url": "http://apicurio:8080/api",
-        "value.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy"
+        "value.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy"
     }
 }

--- a/tutorial/register-mysql-apicurio-converter-json.json
+++ b/tutorial/register-mysql-apicurio-converter-json.json
@@ -14,9 +14,9 @@
         "database.history.kafka.topic": "schema-changes.inventory",
         "key.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter",
         "key.converter.apicurio.registry.url": "http://apicurio:8080/api",
-        "key.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy",
+        "key.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
         "value.converter.apicurio.registry.url": "http://apicurio:8080/api",
         "value.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter",
-        "value.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.AutoRegisterIdStrategy"
+        "value.converter.apicurio.registry.global-id": "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy"
     }
 }


### PR DESCRIPTION
After debezium/docker-images#173 and debezium/docker-images#175 this should update the docs to use new  `ENABLE_APICURIO_CONVERTERS` env var to enable Apicurio converters.