### PR TITLE
[cache-invalidation] Update dependencies

### DIFF
--- a/cache-invalidation/Dockerfile
+++ b/cache-invalidation/Dockerfile
@@ -1,15 +1,15 @@
-FROM jboss/wildfly:14.0.1.Final
+FROM jboss/wildfly:20.0.1.Final
 
 ADD resources/wildfly/customization /opt/jboss/wildfly/customization/
-RUN mkdir /tmp/pg-driver && cd /tmp/pg-driver && curl -sO https://jdbc.postgresql.org/download/postgresql-42.2.5.jar
+RUN mkdir /tmp/pg-driver && cd /tmp/pg-driver && curl -sO https://jdbc.postgresql.org/download/postgresql-42.2.9.jar
 
 RUN mkdir /tmp/infinispan-modules && \
     cd /tmp/infinispan-modules && \
-    curl -sO https://downloads.jboss.org/infinispan/9.4.2.Final/infinispan-wildfly-modules-9.4.2.Final.zip && \
-    unzip infinispan-wildfly-modules-9.4.2.Final.zip && \
-    cp -r infinispan-wildfly-modules-9.4.2.Final/modules/* /opt/jboss/wildfly/modules && \
-    rm infinispan-wildfly-modules-9.4.2.Final.zip && \
-    rm -rf infinispan-wildfly-modules-9.4.2.Final
+    curl -sO https://downloads.jboss.org/infinispan/10.1.8.Final/infinispan-wildfly-modules-10.1.8.Final.zip && \
+    unzip infinispan-wildfly-modules-10.1.8.Final.zip && \
+    cp -r infinispan-wildfly-modules-10.1.8.Final/modules/* /opt/jboss/wildfly/modules && \
+    rm infinispan-wildfly-modules-10.1.8.Final.zip && \
+    rm -rf infinispan-wildfly-modules-10.1.8.Final
 
 # Based on:
 # https://goldmann.pl/blog/2014/07/23/customizing-the-configuration-of-the-wildfly-docker-image/

--- a/cache-invalidation/pom.xml
+++ b/cache-invalidation/pom.xml
@@ -15,9 +15,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <io.debezium.version>0.9.0-SNAPSHOT</io.debezium.version>
+        <io.debezium.version>1.2.5.Final</io.debezium.version>
         <org.hibernate.version>5.3.3.Final</org.hibernate.version>
-        <org.infinispan.version>9.4.2.Final</org.infinispan.version>
+        <org.infinispan.version>10.1.8.Final</org.infinispan.version>
     </properties>
 
     <dependencyManagement>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
+            <version>42.2.9</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/cache-invalidation/resources/wildfly/customization/commands.cli
+++ b/cache-invalidation/resources/wildfly/customization/commands.cli
@@ -2,7 +2,7 @@
 batch
 
 # Add module
-module add --name=org.postgres --resources=/tmp/pg-driver/postgresql-42.2.5.jar --dependencies=javax.api,javax.transaction.api
+module add --name=org.postgres --resources=/tmp/pg-driver/postgresql-42.2.9.jar --dependencies=javax.api,javax.transaction.api
 
 # Add PostgreSQL driver
 /subsystem=datasources/jdbc-driver=postgres:add(driver-name=postgres,driver-module-name=org.postgres,driver-class-name=org.postgresql.Driver)

--- a/cache-invalidation/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/cache-invalidation/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,8 +2,8 @@
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <deployment>
         <dependencies>
-            <module name="org.infinispan" slot="ispn-9.4" services="export"/>
-            <module name="org.infinispan.commons" slot="ispn-9.4" services="export"/>
+            <module name="org.infinispan" slot="ispn-10.1" services="export"/>
+            <module name="org.infinispan.commons" slot="ispn-10.1" services="export"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
* Update Debezium to 1.2.5.Final
* Update WildFly to 20.0.1
* Update Infinispan to 10.1.0.Final
* Update PostgreSQL driver to 42.2.9

This PR supersedes PR #89 as additional components needed to be upgraded.