### PR TITLE
[graphql] Update dependencies

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -27,7 +27,7 @@ mvn clean install -f aggregator/pom.xml
 Start Kafka, Kafka Connect, MySQL, event source and aggregator:
 
 ```shell
-export DEBEZIUM_VERSION=0.8
+export DEBEZIUM_VERSION=1.2
 docker-compose up --build
 ```
 

--- a/graphql/aggregator/pom.xml
+++ b/graphql/aggregator/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <mvn.compiler.version>3.5.1</mvn.compiler.version>
         <mvn.dependency.version>3.0.2</mvn.dependency.version>
-        <apache.kafka.version>2.0.0</apache.kafka.version>
+        <apache.kafka.version>2.5.0</apache.kafka.version>
         <version.thorntail>2.5.0.Final</version.thorntail>
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.com.fasterxml.jackson>2.9.6</version.com.fasterxml.jackson>
@@ -73,7 +73,7 @@
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <version>${apache.kafka.version}</version>
         </dependency>
 

--- a/graphql/example-db/Dockerfile
+++ b/graphql/example-db/Dockerfile
@@ -1,3 +1,3 @@
-FROM debezium/example-mysql:0.9
+FROM debezium/example-mysql:1.2
 
 COPY schema-update.sql /docker-entrypoint-initdb.d/

--- a/graphql/ws-client/pom.xml
+++ b/graphql/ws-client/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.3.9</version>
+            <version>1.5.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* Update Debezium to 1.2
* Update Apache Kafka to 2.5.0
* Update Java WebSocket to 1.5.1

This PR supersedes PR #112 to bring other components and versions up-to-date.