### PR TITLE
DBZ-2693 Added entry-point script for OCP environment

### DIFF
--- a/tutorial/debezium-db2-init/db2server/Dockerfile
+++ b/tutorial/debezium-db2-init/db2server/Dockerfile
@@ -19,3 +19,5 @@ RUN mkdir /var/custom
 RUN chmod -R  777 /var/custom
 
 ADD cdcsetup.sh /var/custom
+ADD custom-init /var/custom-init
+ADD openshift_entrypoint.sh /var/db2_setup/lib/

--- a/tutorial/debezium-db2-init/db2server/custom-init/cleanup_storage.sh
+++ b/tutorial/debezium-db2-init/db2server/custom-init/cleanup_storage.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+################################################################################
+# Wipes the storage directory.
+# Note that this essentially makes the database non-persistent when pod is deleted
+################################################################################
+
+echo "Inspecting database directory"
+ls  $STORAGE_DIR
+
+echo "Wiping database directory"
+rm -rf $STORAGE_DIR/*

--- a/tutorial/debezium-db2-init/db2server/dbsetup.sh
+++ b/tutorial/debezium-db2-init/db2server/dbsetup.sh
@@ -1,5 +1,4 @@
 #/bin/bash
-
 echo "Compile ASN tool ..."
 cd /asncdctools/src
 /opt/ibm/db2/V11.5/samples/c/bldrtn asncdc
@@ -18,7 +17,7 @@ done
 
 # enable metacatalog read via JDBC
 cd $HOME/sqllib/bnd
-db2 bind db2schema.bnd blocking all grant public sqlerror continue 
+db2 bind db2schema.bnd blocking all grant public sqlerror continue
 
 # do a backup and restart the db
 db2 backup db $DBNAME to /dev/null
@@ -43,12 +42,10 @@ db2 -tvmf /asncdctools/src/asncdcaddremove.sql
 
 
 # create sample table and datat
-db2 -tvmf /asncdctools/src/inventory.sql 
-db2 -tvmf /asncdctools/src/startup-agent.sql 
+db2 -tvmf /asncdctools/src/inventory.sql
+db2 -tvmf /asncdctools/src/startup-agent.sql
 sleep 10
-db2 -tvmf /asncdctools/src/startup-cdc-demo.sql 
-
-
+db2 -tvmf /asncdctools/src/startup-cdc-demo.sql
 
 
 echo "done"

--- a/tutorial/debezium-db2-init/db2server/openshift_entrypoint.sh
+++ b/tutorial/debezium-db2-init/db2server/openshift_entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+################################################################################
+#  Runs custom init scripts followed by the original entry point
+###############################################################################
+
+source ${SETUPDIR?}/include/db2_constants
+source ${SETUPDIR?}/include/db2_common_functions
+
+if [[ -d /var/custom-init ]]; then
+    echo "(*) Running user-provided init scripts ... "
+    chmod  -R 777 /var/custom-init
+    for script in `ls /var/custom-init`; do
+       echo "(*) Running $script ..."
+       /var/custom-init/$script
+    done
+fi
+
+echo "Running original entry point"
+/var/db2_setup/lib/setup_db2_instance.sh


### PR DESCRIPTION
Adds entry-point script for OCP with the ability to execute scripts prior to any other db setup. 
Unforuntale DB2 in OCP seems to have issues to start when database directory in emptyDIr volume is not empty and for some reason that happens sometimes. 