### PR TITLE
DBZ-3100 Vitess Connector supports Vitess 9.0.0

### DIFF
--- a/tutorial/debezium-vitess-init/Dockerfile
+++ b/tutorial/debezium-vitess-init/Dockerfile
@@ -1,7 +1,7 @@
 # Use a temporary layer for the build stage.
-FROM vitess/base:v8.0.0 AS base
+FROM vitess/base:v9.0.0 AS base
 
-FROM vitess/lite:v8.0.0
+FROM vitess/lite:v9.0.0
 
 USER root
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3100

Related PRs:

- Vitess Connector Documentation: https://github.com/debezium/debezium/pull/2121
- Compatibility matrix on the website: https://github.com/debezium/debezium.github.io/pull/639