### PR TITLE
Update outbox to the latest stable

### DIFF
--- a/outbox/debezium-strimzi/Dockerfile
+++ b/outbox/debezium-strimzi/Dockerfile
@@ -3,4 +3,4 @@ ENV KAFKA_CONNECT_PLUGIN_PATH=/tmp/connect-plugins
 
 RUN mkdir $KAFKA_CONNECT_PLUGIN_PATH &&\
     cd $KAFKA_CONNECT_PLUGIN_PATH &&\
-    curl -sfSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.4.0.Beta1/debezium-connector-postgres-1.4.0.Beta1-plugin.tar.gz | tar xz
+    curl -sfSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.4.2.Final/debezium-connector-postgres-1.4.2.Final-plugin.tar.gz | tar xz

--- a/outbox/pom.xml
+++ b/outbox/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.debezium-quarkus>1.4.0-SNAPSHOT</version.debezium-quarkus>
-    <version.quarkus>1.10.2.Final</version.quarkus>
+    <version.debezium-quarkus>1.4.2.Final</version.debezium-quarkus>
+    <version.quarkus>1.12.0.Final</version.quarkus>
     <version.surefire>2.22.0</version.surefire>
     <version.kafka.opentracing>0.31.0</version.kafka.opentracing>
   </properties>


### PR DESCRIPTION
The otubox example is no longer buildable du to quarkas changes. This PR aligns dependencies and versions to the latest stable Debezium.

@gunnarmorling One quick fix