### PR TITLE
Regexp restrictied, so patterns like _name are ignored

### DIFF
--- a/monitoring/debezium-grafana/debezium-dashboard.json
+++ b/monitoring/debezium-grafana/debezium-dashboard.json
@@ -1317,7 +1317,7 @@
         ],
         "query": "debezium_metrics_TotalNumberOfEventsSeen{plugin=\"$connector_type\"}",
         "refresh": 0,
-        "regex": "/.*name=\"([^\"]+)\".*/",
+        "regex": "/.*[,\\(]name=\"([^\"]+)\".*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",

--- a/monitoring/debezium-grafana/debezium-mysql-connector-dashboard.json
+++ b/monitoring/debezium-grafana/debezium-mysql-connector-dashboard.json
@@ -2998,7 +2998,7 @@
         "options": [],
         "query": "debezium_metrics_BinlogPosition",
         "refresh": 1,
-        "regex": "/.*name=\"([^\"]+)\".*/",
+        "regex": "/.*[,\\(]name=\"([^\"]+)\".*/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
Strimzi, Kafka on Kubernetes, also generates records with property-names like _name. The regexp was not restricted enough, so it would return values of that property, instead of the property name.