### PR TITLE
Allow dashboard to work with mysql/mariadb events

### DIFF
--- a/monitoring/debezium-grafana/debezium-dashboard.json
+++ b/monitoring/debezium-grafana/debezium-dashboard.json
@@ -1317,7 +1317,7 @@
         ],
         "query": "debezium_metrics_TotalNumberOfEventsSeen{plugin=\"$connector_type\"}",
         "refresh": 0,
-        "regex": "/.*name=\"([^\"]+)\".*/",
+        "regex": "/.*[,\\(]name=\"([^\"]+)\".*/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",

--- a/monitoring/debezium-grafana/debezium-dashboard.json
+++ b/monitoring/debezium-grafana/debezium-dashboard.json
@@ -95,7 +95,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "debezium_metrics_MilliSecondsSinceLastEvent{plugin=\"$connector_type\",name=\"$connector_name\",context=\"streaming\"}",
+          "expr": "debezium_metrics_MilliSecondsSinceLastEvent{plugin=\"$connector_type\",name=\"$connector_name\",context=~\"(binlog|streaming)\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -151,7 +151,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "debezium_metrics_TotalNumberOfEventsSeen{plugin=\"$connector_type\",name=\"$connector_name\",context=\"streaming\"}",
+          "expr": "debezium_metrics_TotalNumberOfEventsSeen{plugin=\"$connector_type\",name=\"$connector_name\",context=~\"(binlog|streaming)\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -159,7 +159,7 @@
           "refId": "A"
         },
         {
-          "expr": "debezium_metrics_NumberOfEventsSkipped{plugin=\"$connector_type\",name=\"$connector_name\",context=\"streaming\"}",
+          "expr": "debezium_metrics_NumberOfEventsSkipped{plugin=\"$connector_type\",name=\"$connector_name\",context=~\"(binlog|streaming)\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Events skipped",
@@ -267,7 +267,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "debezium_metrics_Connected{plugin=\"$connector_type\",name=\"$connector_name\",context=\"streaming\"}",
+          "expr": "debezium_metrics_Connected{plugin=\"$connector_type\",name=\"$connector_name\",context=~\"(binlog|streaming)\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"

--- a/monitoring/debezium-grafana/debezium-mysql-connector-dashboard.json
+++ b/monitoring/debezium-grafana/debezium-mysql-connector-dashboard.json
@@ -2998,7 +2998,7 @@
         "options": [],
         "query": "debezium_metrics_BinlogPosition",
         "refresh": 1,
-        "regex": "/.*name=\"([^\"]+)\".*/",
+        "regex": "/.*[,\\(]name=\"([^\"]+)\".*/",
         "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",


### PR DESCRIPTION
When using debezium-mysql-connector, the context of binlog/streaming events has the value binlog instead of streaming.

Using this change in the dashboard both events are displayed. Arguably, a rewrite rule could in monitoring/debezium-jmx-exporter/config.yml could also work, but using a regular expression seems simpler and less drastic.
