### PR TITLE
Fix JMX configuration for Kafka Connect

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -42,7 +42,8 @@ services:
      - OFFSET_STORAGE_TOPIC=my_connect_offsets
      - STATUS_STORAGE_TOPIC=my_connect_statuses
      - KAFKA_OPTS=-javaagent:/kafka/etc/jmx_prometheus_javaagent.jar=8080:/kafka/etc/config.yml
-     - JMX_PORT=1976
+     - JMXHOST=localhost
+     - JMXPORT=1976
   prometheus:
     build:
       context: debezium-prometheus


### PR DESCRIPTION
JMX metrics of the Kafka Connect worker don't seem to be available with the current configuration. According to image source code (e.g. https://github.com/debezium/docker-images/pull/223) and the [documentation](https://debezium.io/documentation/reference/operations/monitoring.html#kafka-connect-jmx-environment-variables-docker), it should be `JMXPORT` (not `JMX_PORT`) and `JMXHOST`.