### PR TITLE
Use docker-compose when initializing SQL Server database

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -332,7 +332,7 @@ export DEBEZIUM_VERSION=1.6
 docker-compose -f docker-compose-sqlserver.yaml up
 
 # Initialize database and insert test data
-cat debezium-sqlserver-init/inventory.sql | docker exec -i tutorial_sqlserver_1 bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD'
+cat debezium-sqlserver-init/inventory.sql | docker-compose -f docker-compose-sqlserver.yaml exec -T sqlserver bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD'
 
 # Start SQL Server connector
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @register-sqlserver.json


### PR DESCRIPTION
With Docker Compose version v2.0.0, the name of the container running the SQL Server instance is `tutorial-sqlserver-1`, not `tutorial_sqlserver_1`:
```
$ env DEBEZIUM_VERSION=1.7 docker compose -f docker-compose-sqlserver.yaml up
[+] Running 5/5
 ⠿ Network tutorial_default        Created                                                                                             0.1s
 ⠿ Container tutorial-zookeeper-1  Created                                                                                             0.1s
 ⠿ Container tutorial-sqlserver-1  Created                                                                                             0.1s
 ⠿ Container tutorial-kafka-1      Created                                                                                             0.1s
 ⠿ Container tutorial-connect-1    Created                                                                                             0.1s
Attaching to tutorial-connect-1, tutorial-kafka-1, tutorial-sqlserver-1, tutorial-zookeeper-1
```

It's better not to rely on the Docker Compose internals and use `docker-compose` instead of `docker` to execute the command.