### PR TITLE
Fixed db2 example

### DIFF
--- a/tutorial/debezium-db2-init/db2connect/Dockerfile
+++ b/tutorial/debezium-db2-init/db2connect/Dockerfile
@@ -2,7 +2,7 @@ ARG DEBEZIUM_VERSION
 FROM debezium/connect:$DEBEZIUM_VERSION
 
 USER root
-RUN yum -y install libaio curl && yum clean all
+RUN microdnf -y install libaio curl && microdnf clean all
 
 USER kafka
 


### PR DESCRIPTION
Fixed Dockerfile for db2 example using [base](https://github.com/debezium/docker-images/blob/b102abeea2c724d16b936ad5951568bac8ffde40/connect-base/1.9/Dockerfile#L6) as a reference. 

Error:
```
ERROR [2/3] RUN yum -y install libaio curl && yum clean all
[2/3] RUN yum -y install libaio curl && yum clean all:
#6 0.302 /bin/sh: line 1: yum: command not found
```