### PR TITLE
DBZ-4666 - Add kafkastore.bootstrap.servers configs to schema-registry containers

### DIFF
--- a/cloudevents/docker-compose.yaml
+++ b/cloudevents/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       - 8181:8181
       - 8081:8081
     environment:
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
       - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
       - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081

--- a/end-to-end-demo/docker-compose.yaml
+++ b/end-to-end-demo/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
      - 8181:8181
      - 8081:8081
     environment:
+     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081

--- a/tutorial/docker-compose-mysql-avro-connector.yaml
+++ b/tutorial/docker-compose-mysql-avro-connector.yaml
@@ -28,6 +28,7 @@ services:
      - 8181:8181
      - 8081:8081
     environment:
+     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081

--- a/tutorial/docker-compose-mysql-avro-worker.yaml
+++ b/tutorial/docker-compose-mysql-avro-worker.yaml
@@ -28,6 +28,7 @@ services:
      - 8181:8181
      - 8081:8081
     environment:
+     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081


### PR DESCRIPTION
Adds kafkastore.bootstrap.servers to the schema-registry container compose configs. This config option is required in [confluentinc/cp-schema-registry:7.0.0](https://docs.confluent.io/platform/7.0.0/schema-registry/installation/config.html#kafkastore-connection-url) which is being pulled in when the avro examples are run without a local cached version of an older image.  For the purpose of these standalone examples I believe it should be ok to keep the zookeeper connection config around so older versions will still work, but happy to clean it up if it is desired.