### PR TITLE
Remove obsolete Kafka option

### DIFF
--- a/cloudevents/README.md
+++ b/cloudevents/README.md
@@ -108,5 +108,5 @@ You can then establish a remote debugging session from your IDE on localhost:500
 Listing all topics:
 
 ```shell
-docker-compose exec kafka /kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list
+docker-compose exec kafka /kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
 ```

--- a/cloudevents/docker-compose.yaml
+++ b/cloudevents/docker-compose.yaml
@@ -47,13 +47,12 @@ services:
     networks:
      - my-network
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:7.0.1
     ports:
       - 8181:8181
       - 8081:8081
     environment:
       - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
-      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
       - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
       - SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_METHODS=GET,POST,PUT,OPTIONS

--- a/distributed-caching/README.md
+++ b/distributed-caching/README.md
@@ -168,7 +168,7 @@ Alternatively, you can access pgAdmin on http://localhost:5050.
 List all Kafka topics:
 
 ```console
-$ docker-compose exec kafka /kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list
+$ docker-compose exec kafka /kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
 ```
 
 Get the status of the CDC connector:

--- a/end-to-end-demo/README.md
+++ b/end-to-end-demo/README.md
@@ -67,5 +67,5 @@ The configuration used for the hiking-connector and its accompanying jdbc-sink a
 
 ## Misc.
 
-- docker-compose exec kafka /kafka/bin/kafka-topics.sh --list --zookeeper zookeeper:2181
+- docker-compose exec kafka /kafka/bin/kafka-topics.sh --list --bootstrap-server kafka:9092
 - docker-compose exec mysql bash -c 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD inventory'

--- a/end-to-end-demo/debezium-hiking-demo/resources/wildfly/customization/commands.cli
+++ b/end-to-end-demo/debezium-hiking-demo/resources/wildfly/customization/commands.cli
@@ -8,7 +8,7 @@ module add --name=com.mysql --resources=/opt/jboss/wildfly/customization/mysql-c
 /subsystem=datasources/jdbc-driver=mysql:add(driver-name=mysql,driver-module-name=com.mysql,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
 
 # Add the datasource
-data-source add --name=hikingDS --driver-name=mysql --jndi-name=java:jboss/datasources/HikingDS --connection-url=jdbc:mysql://mysql:3306/inventory?useUnicode=true&amp;characterEncoding=UTF-8 --user-name=mysqluser --password=mysqlpw --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+data-source add --name=hikingDS --driver-name=mysql --jndi-name=java:jboss/datasources/HikingDS --connection-url=jdbc:mysql://mysql:3306/inventory?useUnicode=true&amp;characterEncoding=UTF-8&useSSL=false --user-name=mysqluser --password=mysqlpw --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
 
 # Execute the batch
 run-batch

--- a/end-to-end-demo/docker-compose.yaml
+++ b/end-to-end-demo/docker-compose.yaml
@@ -31,13 +31,12 @@ services:
      - POSTGRES_PASSWORD=postgrespw
      - POSTGRES_DB=inventory
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:7.0.1
     ports:
      - 8181:8181
      - 8081:8081
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
-     - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
      - SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_METHODS=GET,POST,PUT,OPTIONS

--- a/kstreams-live-update/demo-os.md
+++ b/kstreams-live-update/demo-os.md
@@ -83,7 +83,7 @@ cat register-mysql-source.json | http POST http://debezium-connect-api:8083/conn
 kafkacat -b my-cluster-kafka-bootstrap -t dbserver1.inventory.categories -C -o beginning | jq ."payload"
 kafkacat -b my-cluster-kafka-bootstrap -t dbserver1.inventory.orders -C -o end | jq ."payload"
 kafkacat -b my-cluster-kafka-bootstrap -t sales_per_category -C -o beginning -K ' --- '
-oc exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --zookeeper localhost:2181 --list
+oc exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
 ```
 
 ## Bonus: Push Data to Elasticsearch
@@ -165,7 +165,7 @@ oc exec -c zookeeper -it my-cluster-zookeeper-0 -- /opt/kafka/bin/kafka-console-
 List topics:
 
 ```
-oc exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --zookeeper localhost:2181 --list
+oc exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
 ```
 
 # Clean-Up

--- a/kstreams-live-update/demo.md
+++ b/kstreams-live-update/demo.md
@@ -44,4 +44,4 @@ http "http://localhost:9200/orders/_search?pretty"
 
 # Misc.
 
-docker-compose  -f docker-compose-mysql exec kafka /kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list
+docker-compose  -f docker-compose-mysql exec kafka /kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list

--- a/saga/README.md
+++ b/saga/README.md
@@ -177,7 +177,7 @@ $ mvn compile quarkus:dev -f customer-service/pom.xml
 Listing all topics:
 
 ```console
-$ docker-compose exec kafka /kafka/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list
+$ docker-compose exec kafka /kafka/bin/kafka-topics.sh --bootstrap-server kafka:9092 --list
 ```
 
 Register connector for logging the saga state:

--- a/tutorial/docker-compose-mysql-avro-connector.yaml
+++ b/tutorial/docker-compose-mysql-avro-connector.yaml
@@ -23,13 +23,12 @@ services:
      - MYSQL_USER=mysqluser
      - MYSQL_PASSWORD=mysqlpw
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:7.0.1
     ports:
      - 8181:8181
      - 8081:8081
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
-     - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
     links:

--- a/tutorial/docker-compose-mysql-avro-worker.yaml
+++ b/tutorial/docker-compose-mysql-avro-worker.yaml
@@ -23,13 +23,12 @@ services:
      - MYSQL_USER=mysqluser
      - MYSQL_PASSWORD=mysqlpw
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:7.0.1
     ports:
      - 8181:8181
      - 8081:8081
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
-     - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
     links:


### PR DESCRIPTION
* replace outdated the `--zookeeper` option with the `--bootstrap-server` option
* remove `SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL`
* pin the version of the Confluent registry image
* fix end-to-end demo

https://issues.redhat.com/browse/DBZ-4660