### PR TITLE
Correct parameter KAFKA_CONNECT_URIS

### DIFF
--- a/ui-demo/docker-compose.yaml
+++ b/ui-demo/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - KAFKA_CONNECT_URI=http://connect:8083
+      - KAFKA_CONNECT_URIS=http://connect:8083
     depends_on:
       - connect
     networks:


### PR DESCRIPTION
As per documentation:

https://debezium.io/documentation/reference/stable/operations/debezium-ui.html

The correct naming for the parameter is KAFKA_CONNECT_URIS