### PR TITLE
Fix dockerfile using microdnf instead of yum

### DIFF
--- a/kstreams/debezium-mongodb/Dockerfile
+++ b/kstreams/debezium-mongodb/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/debezium/connect:1.8
 ENV KAFKA_CONNECT_MONGODB_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-mongodb
 
 USER root
-RUN yum -y install git maven && yum clean all
+RUN microdnf -y install git maven && microdnf clean all
 
 USER kafka
 


### PR DESCRIPTION
### Description
* Currently, dockerfile for kstreasm example is not working due to Debezium docker image is using fedora minimal image, which does not include yum.
* The purpose of this tiny PR is to fix that replacing it for microdnf.