### PR TITLE
Fix kstreams dockerfile to bump fedora-minimal to a version available

### DIFF
--- a/kstreams/poc-ddd-aggregates/Dockerfile
+++ b/kstreams/poc-ddd-aggregates/Dockerfile
@@ -28,7 +28,7 @@ COPY src /tmp/poc-ddd-aggregates/src
 RUN mvn package -DskipTests -o -f /tmp/poc-ddd-aggregates/pom.xml
 
 # 3. Create actual image (jlink-ed JDK, dependencies, JAR and launcher)
-FROM registry.fedoraproject.org/fedora-minimal:29
+FROM registry.fedoraproject.org/fedora-minimal:32
 
 COPY --from=jdk /opt/jre-minimal /opt/poc-ddd-aggregates/jdk
 RUN cd /opt/poc-ddd-aggregates \

--- a/kstreams/poc-ddd-aggregates/Dockerfile
+++ b/kstreams/poc-ddd-aggregates/Dockerfile
@@ -28,7 +28,7 @@ COPY src /tmp/poc-ddd-aggregates/src
 RUN mvn package -DskipTests -o -f /tmp/poc-ddd-aggregates/pom.xml
 
 # 3. Create actual image (jlink-ed JDK, dependencies, JAR and launcher)
-FROM registry.fedoraproject.org/fedora-minimal:32
+FROM registry.fedoraproject.org/fedora-minimal:37
 
 COPY --from=jdk /opt/jre-minimal /opt/poc-ddd-aggregates/jdk
 RUN cd /opt/poc-ddd-aggregates \


### PR DESCRIPTION
### Description
* Currently DDD dockerfile is not working due to fedora registry image 29 not being present anymore.
 * In this PR I upgrade it to 32
 * Current tags [link](https://registry.fedoraproject.org/repo/fedora-minimal/tags/)
