### PR TITLE
DBZ-5174 Updated to Strimzi 0.29 and Debezium 1.9

### DIFF
--- a/outbox/debezium-strimzi/Dockerfile
+++ b/outbox/debezium-strimzi/Dockerfile
@@ -1,6 +1,9 @@
-FROM strimzi/kafka:0.20.0-kafka-2.6.0
+ARG STRIMZI_VERSION=0.29.0-kafka-3.1.0
+FROM quay.io/strimzi/kafka:${STRIMZI_VERSION}
+
+ARG DEBEZIUM_CONNECTOR_VERSION=1.9.2.Final
 ENV KAFKA_CONNECT_PLUGIN_PATH=/tmp/connect-plugins
 
 RUN mkdir $KAFKA_CONNECT_PLUGIN_PATH &&\
     cd $KAFKA_CONNECT_PLUGIN_PATH &&\
-    curl -sfSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.7.1.Final/debezium-connector-postgres-1.7.1.Final-plugin.tar.gz | tar xz
+    curl -sfSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/${DEBEZIUM_CONNECTOR_VERSION}/debezium-connector-postgres-${DEBEZIUM_CONNECTOR_VERSION}-plugin.tar.gz | tar xz

--- a/outbox/docker-compose.yaml
+++ b/outbox/docker-compose.yaml
@@ -61,6 +61,9 @@ services:
     image: debezium/strimzi-connect
     build:
       context: debezium-strimzi
+      args:
+        DEBEZIUM_VERSION: "${DEBEZIUM_CONNECTOR_VERSION:-1.9.2.Final}"
+        STRIMZI_VERSION: "${STRIMZI_VERSION:-0.29.0-kafka-3.1.0}"
     ports:
      - 8083:8083
     links:

--- a/outbox/order-service/pom.xml
+++ b/outbox/order-service/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-opentracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/outbox/pom.xml
+++ b/outbox/pom.xml
@@ -12,8 +12,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.debezium-quarkus>1.7.1.Final</version.debezium-quarkus>
-    <version.quarkus>2.0.0.Final</version.quarkus>
+    <version.debezium-quarkus>1.9.2.Final</version.debezium-quarkus>
+    <version.quarkus>2.7.2.Final</version.quarkus>
     <version.surefire>2.22.0</version.surefire>
     <version.kafka.opentracing>0.31.0</version.kafka.opentracing>
   </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5174

Updates version of Debezium and Strimzi to latest stable releases for outbox example.

