### PR TITLE
[Debezium Server NameMapper PubSub] Switch to Debezium 2.0

### DIFF
--- a/debezium-server-name-mapper/README.md
+++ b/debezium-server-name-mapper/README.md
@@ -20,7 +20,7 @@ Both Apache Pulsar and the source database are deployed via Docker Compose file.
 From terminal start the source database and the sink system:
 
 ```
-$ export DEBEZIUM_VERSION=1.9
+$ export DEBEZIUM_VERSION=2.0
 $ docker compose up
 ```
 

--- a/debezium-server-name-mapper/README.md
+++ b/debezium-server-name-mapper/README.md
@@ -10,12 +10,10 @@ The configuration option is configured either via `application.properties` confi
 
 As an example, when setting `mapper.prefix` to the value `superprefix`, then a message intended to be delivered to the topic `server.schema.table` would be routed to topic `superprefix.server.schema.table`.
 
-
 ## Topology
 
 This demo uses Apache Pulsar as the sink and the standard Debezium example PostgreSQL database.
 Both Apache Pulsar and the source database are deployed via Docker Compose file.
-
 
 ## How to run
 
@@ -23,7 +21,7 @@ From terminal start the source database and the sink system:
 
 ```
 $ export DEBEZIUM_VERSION=1.9
-$ docker-compose up
+$ docker compose up
 ```
 
 In another terminal build the custom naming policy class and the runner JAR to start the application:
@@ -41,7 +39,7 @@ $ java -jar target/quarkus-app/quarkus-run.jar
 In another terminal check the created topics:
 
 ```
-docker-compose exec pulsar bin/pulsar-admin broker-stats topics -i
+docker compose exec pulsar bin/pulsar-admin broker-stats topics -i
 ```
 
 The resulting topic list should contain for example a topic named

--- a/debezium-server-name-mapper/pom.xml
+++ b/debezium-server-name-mapper/pom.xml
@@ -10,9 +10,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.debezium>1.9.5.Final</version.debezium>
-        <version.debezium.tag>1.9</version.debezium.tag>
-        <version.quarkus>2.7.2.Final</version.quarkus>
+        <version.debezium>2.0.0.Final</version.debezium>
+        <version.debezium.tag>2.0</version.debezium.tag>
+        <version.quarkus>2.11.0.Final</version.quarkus>
         <version.jandex>1.2.3</version.jandex>
     </properties>
 
@@ -38,6 +38,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>3.3.1</version>
+            </dependency>
             <dependency>
                 <groupId>io.debezium</groupId>
                 <artifactId>debezium-server-pulsar</artifactId>

--- a/debezium-server-name-mapper/src/main/resources/application.properties
+++ b/debezium-server-name-mapper/src/main/resources/application.properties
@@ -8,11 +8,6 @@ debezium.source.database.port=5432
 debezium.source.database.user=postgres
 debezium.source.database.password=postgres
 debezium.source.database.dbname=postgres
-debezium.source.database.server.name=tutorial
+debezium.source.topic.prefix=tutorial
 debezium.source.schema.include.list=inventory
-
-# Needed till https://issues.redhat.com/browse/DBZ-2192 is released
-quarkus.index-dependency.pulsar.group-id=io.debezium
-quarkus.index-dependency.pulsar.artifact-id=debezium-server-pulsar
-
 mapper.prefix=superprefix


### PR DESCRIPTION
This one was failing with [missing method](https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L1442). This method is not present in kafka-clients:3.1 (which is defined in quarkus' BOM). The exclusion and manual alignment seems to do the trick, although I'm not sure if this should be the solution