### PR TITLE
Update the way environment variables are set in Docker compose file

### DIFF
--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -26,7 +26,8 @@ This demo automatically deploys the topology of services as defined in the [Debe
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-mysql.yaml up
 
 # Start MySQL connector
@@ -196,7 +197,7 @@ docker run --rm --tty \
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-postgres.yaml up
 
 # Start Postgres connector
@@ -220,7 +221,7 @@ docker-compose -f docker-compose-postgres.yaml down
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-mongodb.yaml up
 
 # Initialize MongoDB replica set and insert some test data
@@ -255,7 +256,7 @@ and set up with the configuration, users and grants described in the Debezium [V
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-oracle.yaml up --build
 
 # Insert test data
@@ -295,7 +296,7 @@ docker-compose -f docker-compose-oracle.yaml down
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-sqlserver.yaml up
 
 # Initialize database and insert test data
@@ -322,7 +323,7 @@ docker-compose -f docker-compose-sqlserver.yaml down
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 
 docker-compose -f docker-compose-db2.yaml up --build
 
@@ -348,7 +349,7 @@ docker-compose -f docker-compose-db2.yaml down
 
 ```shell 
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 
 docker-compose -f docker-compose-cassandra.yaml up --build
 
@@ -376,7 +377,7 @@ docker-compose -f docker-compose-cassandra.yaml down
 
 ```shell 
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 
 docker-compose -f docker-compose-vitess.yaml up --build
 
@@ -437,7 +438,7 @@ The configuration is done at both worker and connector level.
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-mysql-ext-secrets.yaml up
 
 # Start MySQL connector
@@ -456,7 +457,7 @@ Since Apache Kafka 2.8 and Debezium 1.7, there is **experimental** support for r
 
 ```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
-export DEBEZIUM_VERSION=2.1
+echo DEBEZIUM_VERSION=2.1 > .env
 docker-compose -f docker-compose-zookeeperless-kafka-combined.yaml up
 
 # Start Postgres connector


### PR DESCRIPTION
Hi! 
First, I'm not familer to English, so I apologize for the awkwardness.

While following the tutorial, I noticed that export DEBEZIUM_VERSION doesn't apply.
And I found out that I need to set up a separate environment variable file (.env) to solve this problem.
What do you think about updating the README.md document to clear up confusion when running the tutorial?

Thanks!