### PR TITLE
Update Connect Service Image Version

### DIFF
--- a/ui-demo/docker-compose.yaml
+++ b/ui-demo/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
     command: bash -c 'sleep 20 && mongo -u admin -p admin --authenticationDatabase admin db-mongo:27017/inventory --eval "rs.initiate();"'
   connect:
     container_name: connect
-    image: quay.io/debezium/connect:nightly
+    image: quay.io/debezium/connect:${DEBEZIUM_VERSION}
     ports:
       - "8083:8083"
     depends_on:


### PR DESCRIPTION
There's inconsistency in the compose.yaml file. Kafka Connect is using the nightly image. I have updated it to use ${DEBEZIUM_VERSION} instead.

This solves the version mismatch problem, allowing the docker image will work as expected, without any issues.