### PR TITLE
Add tutorial for Debezium Server with Redis and Pub/Sub emulator

### DIFF
--- a/debezium-server/debezium-server-mysql-redis-pubsub/Dockerfile
+++ b/debezium-server/debezium-server-mysql-redis-pubsub/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+RUN apt update && apt install -y git
+RUN git clone https://github.com/googleapis/python-pubsub.git
+
+WORKDIR python-pubsub/samples/snippets
+RUN pip install -r requirements.txt

--- a/debezium-server/debezium-server-mysql-redis-pubsub/README.md
+++ b/debezium-server/debezium-server-mysql-redis-pubsub/README.md
@@ -1,0 +1,92 @@
+# Debezium Server sink to Pub/Sub emulator with Redis storage
+
+## Overview
+
+This example demonstrates how to deploy [Debezium Server](https://debezium.io/documentation/reference/stable/operations/debezium-server.html) using MySQL as data sources, Redis and storage for offset and schema history, and [Google Cloud Pub/Sub emulator](https://cloud.google.com/pubsub/docs) as a destination.
+
+
+## Prerequisites
+
+Before getting started, ensure you have the following prerequisites:
+
+1. Docker
+2. To use emulator, you can either:
+    - Write your own application using [Cloud Client Libraries](https://cloud.google.com/pubsub/libraries#gcloud-libraries)
+    - or Use `docker compose run --rm pubsub_tools bash -c '...'` which based on [python-pubsub/samples/snippets](https://github.com/googleapis/python-pubsub/tree/main/samples/snippets)
+
+    The emulator DOES NOT support Google Cloud console or `gcloud pubsub` commands. 
+
+## Project Structure
+```
+└── debezium-server/debezium-server-sink-pubsub
+    ├── config-mysql
+    │   └── application.properties
+    ├── docker-compose.yml
+    ├── Dockerfile
+    └── README.md
+```
+
+- `config-mysql/application.properties` MySQL configuration of the Debezium Connector.
+- `docker-compose.yml` is used for defining and running Debezium Server and the databases via Docker Compose.
+- `Dockerfile` is used for setup `pubsub_tools` which contains useful CLI tools to work with Pub/Sub emulator.
+- `README.md` is an essential guide for this example.
+
+## How to run
+1. Setup environment variables
+```bash
+export DEBEZIUM_VERSION=2.7
+
+# Or create .env for docker compose
+echo 'DEBEZIUM_VERSION=2.7' > .env
+```
+
+2. Start all dependencies services
+```bash
+docker compose up -d mysql redis pubsub
+```
+
+- `mysql`: accessible via port `3306`
+- `redis`: accessible via port `6379`
+- `pubsub`: accessible via port `8085` with project `debezium-tutorial-local`
+
+3. Setup Pub/Sub emulator
+- Create GCP Pub/Sub topics in Pub/Sub emulator from terminal
+
+```bash
+# Topic for schema history
+docker compose run --rm pubsub_tools bash -c 'python publisher.py $PUBSUB_PROJECT_ID create tutorial'
+
+# Topic for inventory.customers table
+docker compose run --rm pubsub_tools bash -c 'python publisher.py $PUBSUB_PROJECT_ID create tutorial.inventory.customers'
+```
+
+- Setup Pub/Sub emulator subscriptions. For each topic above, we can create either pull or subscription to the emulator and observe the changes
+
+```bash
+# Pull subscription
+docker compose run --rm pubsub_tools bash -c 'python subscriber.py $PUBSUB_PROJECT_ID create tutorial.inventory.customers customers-pull-sub'
+
+# Retrieve messages from your pull subscription
+docker compose run --rm pubsub_tools bash -c 'python subscriber.py $PUBSUB_PROJECT_ID receive customers-pull-sub'
+```
+
+**NOTE**: If you don't use docker compose `pubsub_tools` above, [follow instructions how to use the emulator](https://cloud.google.com/pubsub/docs/emulator#using_the_emulator). These environment variables must be set:
+```bash
+export PUBSUB_EMULATOR_HOST=0.0.0.0:8085
+export PUBSUB_PROJECT_ID=debezium-tutorial-local
+```
+
+
+5. Start Debezium Server:
+```bash
+docker compose up -d debezium-server-mysql
+```
+
+6. Test the setup by making changes to the customers table.
+
+You can access MySQL with this command:
+```bash
+docker compose exec mysql bash -c 'mysql -u $MYSQL_USER -p$MYSQL_PASSWORD'
+```
+
+Observe the logs depending on the subscription you setup

--- a/debezium-server/debezium-server-mysql-redis-pubsub/config-mysql/application.properties
+++ b/debezium-server/debezium-server-mysql-redis-pubsub/config-mysql/application.properties
@@ -1,0 +1,37 @@
+# Source
+debezium.source.connector.class=io.debezium.connector.mysql.MySqlConnector
+debezium.source.database.hostname=mysql
+debezium.source.database.server.id=223344
+debezium.source.database.port=3306
+debezium.source.database.user=debezium
+debezium.source.database.password=dbz
+
+debezium.source.database.include.list=inventory
+debezium.source.table.include.list=inventory.customers
+debezium.source.topic.prefix=tutorial
+
+# Offset configuration
+debezium.source.offset.storage=io.debezium.storage.redis.offset.RedisOffsetBackingStore
+debezium.source.offset.storage.redis.address=redis:6379
+debezium.source.offset.storage.redis.password=myredispw
+debezium.source.offset.storage.redis.key=metadata:debezium:offsets
+debezium.source.offset.storage.redis.wait.enabled=false
+debezium.source.offset.storage.redis.wait.retry.enabled=true
+debezium.source.offset.storage.redis.wait.retry.delay.ms=5000
+
+# Schema history
+debezium.source.schema.history.internal=io.debezium.storage.redis.history.RedisSchemaHistory
+debezium.source.schema.history.internal.redis.address=redis:6379
+debezium.source.schema.history.internal.redis.password=myredispw
+debezium.source.schema.history.internal.redis.key=metadata:debezium:schema_history
+debezium.source.schema.history.internal.redis.wait.enabled=false
+debezium.source.schema.history.internal.redis.wait.retry.enabled=true
+debezium.source.schema.history.internal.redis.wait.retry.delay.ms=5000
+
+# Sink
+debezium.sink.type=pubsub
+debezium.sink.pubsub.project.id=debezium-tutorial-local
+debezium.sink.pubsub.address=pubsub:8085
+
+# Logging
+quarkus.log.console.json=false

--- a/debezium-server/debezium-server-mysql-redis-pubsub/docker-compose.yml
+++ b/debezium-server/debezium-server-mysql-redis-pubsub/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  mysql:
+    image: quay.io/debezium/example-mysql:${DEBEZIUM_VERSION}
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=debezium
+      - MYSQL_USER=mysqluser
+      - MYSQL_PASSWORD=mysqlpw
+
+  redis:
+    image: bitnami/redis:7.0
+    ports:
+      - 6379:6379
+    environment:
+      - REDIS_PASSWORD=myredispw
+
+  pubsub:
+    image: google/cloud-sdk:486.0.0-emulators
+    command: gcloud beta emulators pubsub start --project debezium-tutorial-local --host-port 0.0.0.0:8085
+    ports:
+      - 8085:8085
+
+  debezium-server-mysql:
+    image: quay.io/debezium/server:${DEBEZIUM_VERSION}
+    ports:
+      - 8080:8080
+    volumes:
+      - ./config-mysql:/debezium/conf
+
+  pubsub_tools:
+    build: .
+    environment:
+      - PUBSUB_PROJECT_ID=debezium-tutorial-local
+      - PUBSUB_EMULATOR_HOST=pubsub:8085
+    depends_on:
+      - pubsub


### PR DESCRIPTION
Related to https://github.com/debezium/debezium/pull/5731

This example has two objectives:
1. Try Redis as `RedisOffsetBackingStore` and `RedisSchemaHistory`. By stopping and restarting Redis, I managed to reproduce the issue in https://issues.redhat.com/browse/DBZ-7879

2. Although we do have an example with Pub/Sub in `debezium-server/debezium-server-sink-pubsub`,  it requires GCP project with authentication, which is not ideal for local testing
-> This example Pub/Sub emulator instead