### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/ui-demo/docker-compose.yaml
+++ b/ui-demo/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
     command: bash -c 'sleep 20 && mongo -u admin -p admin --authenticationDatabase admin db-mongo:27017/inventory --eval "rs.initiate();"'
   connect:
     container_name: connect
-    image: quay.io/debezium/connect:nightly
+    image: quay.io/debezium/connect:${DEBEZIUM_VERSION}
     ports:
       - "8083:8083"
     depends_on:


### PR DESCRIPTION
fix: debezium-ui:nightly can not run with kafka:2.5

## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->

## Checklist

- [ ] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file