### PR TITLE
[mongo-images] improved rs initialisation for compose environments

### DIFF
--- a/debezium-server/debezium-server-sink-pubsub/README.md
+++ b/debezium-server/debezium-server-sink-pubsub/README.md
@@ -88,13 +88,7 @@ docker compose exec postgres env PGOPTIONS="--search_path=inventory" bash -c 'ps
 Start the database container:
 
 ```shell
-docker compose up -d mongodb
-```
-
-Initialize MongoDB replica set and insert some test data
-
-```shell
-docker compose exec mongodb bash -c '/usr/local/bin/init-inventory.sh'
+docker compose up -d mongodb mongodb-init
 ```
 
 Start Debezium Server:

--- a/debezium-server/debezium-server-sink-pubsub/docker-compose.yml
+++ b/debezium-server/debezium-server-sink-pubsub/docker-compose.yml
@@ -1,21 +1,36 @@
-version: '3.9'
+version: "3.9"
 services:
   postgres:
     image: quay.io/debezium/example-postgres:${DEBEZIUM_VERSION}
     container_name: postgres
     ports:
-     - "5432:5432"
+      - "5432:5432"
     environment:
-     - POSTGRES_USER=postgres
-     - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
   mongodb:
-    image: quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
-    container_name: mongodb
+    image: &mongodb-image quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
+    hostname: &mongodb-hostname mongodb
     ports:
-      - "27017:27017"
+      - 27017:27017
     environment:
-      - MONGODB_USER=debezium
-      - MONGODB_PASSWORD=dbz
+      MONGODB_USER: debezium
+      MONGODB_PASSWORD: dbz
+    healthcheck:
+      test: bash -c 'mongosh --quiet --eval "db.adminCommand(\"ping\").ok" localhost:27017 | grep 1'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+  mongodb-init:
+    image: *mongodb-image
+    environment:
+      HOSTNAME: *mongodb-hostname
+    entrypoint: /bin/bash
+    command: "/usr/local/bin/init-inventory.sh"
+    depends_on:
+      mongodb:
+        condition: service_healthy
   mysql:
     image: quay.io/debezium/example-mysql:${DEBEZIUM_VERSION}
     container_name: mysql

--- a/mongodb-outbox/README.md
+++ b/mongodb-outbox/README.md
@@ -6,9 +6,6 @@ export DEBEZIUM_VERSION=2.1
 export DEBEZIUM_CONNECTOR_VERSION=2.1.3.Final
 docker compose up --build
 
-# Initialize MongoDB replica set and insert some test data
-docker compose exec mongodb bash -c '/usr/local/bin/init-inventory.sh'
-
 # Start MongoDB connector
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @register-mongodb.json
 

--- a/mongodb-outbox/docker-compose.yaml
+++ b/mongodb-outbox/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   jaeger:
     image: jaegertracing/all-in-one:1
@@ -76,13 +74,30 @@ services:
     depends_on:
       - kafka
   mongodb:
-    image: quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
-    hostname: mongodb
+    image: &mongodb-image quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
+    hostname: &mongodb-hostname mongodb
     ports:
       - 27017:27017
     environment:
-      - MONGODB_USER=debezium
-      - MONGODB_PASSWORD=dbz
+      MONGODB_USER: debezium
+      MONGODB_PASSWORD: dbz
+    healthcheck:
+      test: bash -c 'mongosh --quiet --eval "db.adminCommand(\"ping\").ok" localhost:27017 | grep 1'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - my-network
+  mongodb-init:
+    image: *mongodb-image
+    environment:
+      HOSTNAME: *mongodb-hostname
+    entrypoint: /bin/bash
+    command: "/usr/local/bin/init-inventory.sh"
+    depends_on:
+      mongodb:
+        condition: service_healthy
     networks:
       - my-network
 networks:

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -52,7 +52,7 @@ docker-compose -f docker-compose-mysql.yaml down
 ### Using MySQL and the Avro message format
 
 To use [Avro-style messages](https://debezium.io/documentation/reference/stable/configuration/avro.html) instead of JSON,
-Avro can be configured one of two ways, 
+Avro can be configured one of two ways,
 in the Kafka Connect worker configuration or in the connector configuration.
 Using Avro in conjunction with the schema registry allows for much more compact messages.
 
@@ -258,9 +258,6 @@ docker-compose -f docker-compose-postgres.yaml down
 export DEBEZIUM_VERSION=2.1
 docker-compose -f docker-compose-mongodb.yaml up
 
-# Initialize MongoDB replica set and insert some test data
-docker-compose -f docker-compose-mongodb.yaml exec mongodb bash -c '/usr/local/bin/init-inventory.sh'
-
 # Start MongoDB connector
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @register-mongodb.json
 
@@ -381,7 +378,7 @@ docker-compose -f docker-compose-db2.yaml down
 
 ## Using Cassandra
 
-```shell 
+```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
 export DEBEZIUM_VERSION=2.1
 
@@ -409,7 +406,7 @@ docker-compose -f docker-compose-cassandra.yaml down
 
 ## Using Vitess
 
-```shell 
+```shell
 # Start the topology as defined in https://debezium.io/documentation/reference/stable/tutorial.html
 export DEBEZIUM_VERSION=2.7
 
@@ -439,11 +436,11 @@ docker-compose -f docker-compose-vitess.yaml down
 In this example, the Vitess setup has 2 keyspaces (a.k.a. schemas in MySQL's term):
 
 - 1 unsharded keyspace: `customer`, which contains 1 table `customer`, and some technical Sequence tables used by Vitess itself.
-- 1 sharded keyspace: `inventory`, which contains 3 tables `products`, `products_on_hand` and `orders`. This sharded keyspace has 2 shards (`-80` and `80-`), the sharding key is the product id column of each of the 3 tables, this is, the `id` column in the `products` table, the `product_id` column in the `products_on_hand` table, the `product_id` column in the `orders` table. 
+- 1 sharded keyspace: `inventory`, which contains 3 tables `products`, `products_on_hand` and `orders`. This sharded keyspace has 2 shards (`-80` and `80-`), the sharding key is the product id column of each of the 3 tables, this is, the `id` column in the `products` table, the `product_id` column in the `products_on_hand` table, the `product_id` column in the `orders` table.
 
 The unsharded keyspace `customer` has only 1 shard, the sharded keyspace `inventory` has 2 shards. Each shard consists of their own MySQL cluster that has 3 MySQL processes: 1 master and 2 replicas. Vitess uses 1 instance of `vttablet` as the sidecar for each MySQL process.
 
-There are 3 other Vitess processes running in the same container: `vtgate`, `vtctld` and `etcd`. Typically, MySQL clients (e.g. JDBC) send queries to `vtgate`, who routes queries to `vttablets`, who in turn run the query in their local MySQL instance. `vtctld` is a long-running process for admin operations such as adding new keyspaces. Keyspaces' metadata (a.k.a topology) is stored in `etcd`. `vtgate` is stateless and reads the topology from `etcd` and cache it locally. 
+There are 3 other Vitess processes running in the same container: `vtgate`, `vtctld` and `etcd`. Typically, MySQL clients (e.g. JDBC) send queries to `vtgate`, who routes queries to `vttablets`, who in turn run the query in their local MySQL instance. `vtctld` is a long-running process for admin operations such as adding new keyspaces. Keyspaces' metadata (a.k.a topology) is stored in `etcd`. `vtgate` is stateless and reads the topology from `etcd` and cache it locally.
 
 In summary, the following diagram shows the Vitess container's sharding setup and all the processes running inside the Vitess container:
 
@@ -535,7 +532,7 @@ docker-compose -f docker-compose-mariadb.yaml exec kafka /kafka/bin/kafka-consol
     --from-beginning \
     --property print.key=true \
     --topic dbserver1.inventory.customers
-    
+
 # Modify records in the database via MariaDB client
 docker compose -f docker-compose-mariadb.yaml exec mariadb bash -c 'mariadb -u $MARIADB_USER -p$MARIADB_PASSWORD inventory'
 

--- a/tutorial/docker-compose-mongodb.yaml
+++ b/tutorial/docker-compose-mongodb.yaml
@@ -1,40 +1,49 @@
-version: '2'
 services:
   zookeeper:
     image: quay.io/debezium/zookeeper:${DEBEZIUM_VERSION}
     ports:
-     - 2181:2181
-     - 2888:2888
-     - 3888:3888
+      - 2181:2181
+      - 2888:2888
+      - 3888:3888
   kafka:
     image: quay.io/debezium/kafka:${DEBEZIUM_VERSION}
     ports:
-     - 9092:9092
-    links:
-     - zookeeper
+      - 9092:9092
     environment:
-     - ZOOKEEPER_CONNECT=zookeeper:2181
+      ZOOKEEPER_CONNECT: zookeeper:2181
   mongodb:
-    image: quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
-    hostname: mongodb
+    image: &mongodb-image quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
+    hostname: &mongodb-hostname mongodb
     ports:
-     - 27017:27017
+      - 27017:27017
     environment:
-     - MONGODB_USER=debezium
-     - MONGODB_PASSWORD=dbz
+      MONGODB_USER: debezium
+      MONGODB_PASSWORD: dbz
+    healthcheck:
+      test: bash -c 'mongosh --quiet --eval "db.adminCommand(\"ping\").ok" localhost:27017 | grep 1'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+  mongodb-init:
+    image: *mongodb-image
+    environment:
+      HOSTNAME: *mongodb-hostname
+    entrypoint: /bin/bash
+    command: "/usr/local/bin/init-inventory.sh"
+    depends_on:
+      mongodb:
+        condition: service_healthy
   connect:
     image: quay.io/debezium/connect:${DEBEZIUM_VERSION}
     ports:
-     - 8083:8083
-    links:
-     - kafka
-     - mongodb
+      - 8083:8083
     environment:
-     - BOOTSTRAP_SERVERS=kafka:9092
-     - GROUP_ID=1
-     - CONFIG_STORAGE_TOPIC=my_connect_configs
-     - OFFSET_STORAGE_TOPIC=my_connect_offsets
-     - STATUS_STORAGE_TOPIC=my_connect_statuses
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: my_connect_configs
+      OFFSET_STORAGE_TOPIC: my_connect_offsets
+      STATUS_STORAGE_TOPIC: my_connect_statuses
 # For testing newer connector versions, unpack the connector archive into this
 # directory and uncomment the lines below
 #    volumes:

--- a/unwrap-mongodb-smt/README.md
+++ b/unwrap-mongodb-smt/README.md
@@ -19,14 +19,11 @@ We are using Docker Compose to deploy the following components:
 export DEBEZIUM_VERSION=2.1
 docker compose up --build -d
 
-# Initialize MongoDB replica set and insert some test data
-docker compose exec mongodb bash -c '/usr/local/bin/init-inventory.sh'
-
 # Current host
 # if using docker-machine:
 export CURRENT_HOST=$(docker-machine ip $(docker-machine active));
 # or any other host
-# export CURRENT_HOST='localhost' //or your host name 
+# export CURRENT_HOST='localhost' //or your host name
 
 # Start JDBC sink connector
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://$CURRENT_HOST:8083/connectors/ -d @jdbc-sink.json
@@ -135,7 +132,7 @@ db.customers.remove(
    {
     _id: NumberLong("1005")
    }
-);   
+);
 ```
 
 Verify that record in PostgreSQL is deleted:

--- a/unwrap-mongodb-smt/docker-compose.yaml
+++ b/unwrap-mongodb-smt/docker-compose.yaml
@@ -1,34 +1,49 @@
-version: '2'
 services:
   zookeeper:
     image: quay.io/debezium/zookeeper:${DEBEZIUM_VERSION}
     ports:
-     - 2181:2181
-     - 2888:2888
-     - 3888:3888
+      - 2181:2181
+      - 2888:2888
+      - 3888:3888
   kafka:
     image: quay.io/debezium/kafka:${DEBEZIUM_VERSION}
     ports:
-     - 9092:9092
+      - 9092:9092
     links:
-     - zookeeper
+      - zookeeper
     environment:
-     - ZOOKEEPER_CONNECT=zookeeper:2181
+      - ZOOKEEPER_CONNECT=zookeeper:2181
   mongodb:
-    image: quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
+    image: &mongodb-image quay.io/debezium/example-mongodb:${DEBEZIUM_VERSION}
+    hostname: &mongodb-hostname mongodb
     ports:
-     - 27017:27017
+      - 27017:27017
     environment:
-     - MONGODB_USER=debezium
-     - MONGODB_PASSWORD=dbz
+      MONGODB_USER: debezium
+      MONGODB_PASSWORD: dbz
+    healthcheck:
+      test: bash -c 'mongosh --quiet --eval "db.adminCommand(\"ping\").ok" localhost:27017 | grep 1'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+  mongodb-init:
+    image: *mongodb-image
+    environment:
+      HOSTNAME: *mongodb-hostname
+    entrypoint: /bin/bash
+    command: "/usr/local/bin/init-inventory.sh"
+    depends_on:
+      mongodb:
+        condition: service_healthy
   postgres:
     image: quay.io/debezium/postgres:11
     ports:
-     - "5432:5432"
+      - "5432:5432"
     environment:
-     - POSTGRES_USER=postgresuser
-     - POSTGRES_PASSWORD=postgrespw
-     - POSTGRES_DB=inventorydb
+      - POSTGRES_USER=postgresuser
+      - POSTGRES_PASSWORD=postgrespw
+      - POSTGRES_DB=inventorydb
   connect:
     image: debezium/connect-jdbc:${DEBEZIUM_VERSION}
     build:
@@ -36,14 +51,14 @@ services:
       args:
         DEBEZIUM_VERSION: ${DEBEZIUM_VERSION}
     ports:
-     - 8083:8083
+      - 8083:8083
     links:
-     - kafka
-     - mongodb
-     - postgres
+      - kafka
+      - mongodb
+      - postgres
     environment:
-     - BOOTSTRAP_SERVERS=kafka:9092
-     - GROUP_ID=1
-     - CONFIG_STORAGE_TOPIC=my_connect_configs
-     - OFFSET_STORAGE_TOPIC=my_connect_offsets
-     - STATUS_STORAGE_TOPIC=my_source_connect_statuses
+      - BOOTSTRAP_SERVERS=kafka:9092
+      - GROUP_ID=1
+      - CONFIG_STORAGE_TOPIC=my_connect_configs
+      - OFFSET_STORAGE_TOPIC=my_connect_offsets
+      - STATUS_STORAGE_TOPIC=my_source_connect_statuses


### PR DESCRIPTION
Relates to https://github.com/debezium/container-images/pull/455

Tutorial works
unwrap requires an image which I am not able to test at the moment due to platform incompatibility (pg example image supposedly) 
Outbox example fails with 
```
onnect-1       | [2025-05-26 12:59:40,109] ERROR [outbox-connector|task-0] Failed to start task outbox-connector-0 (org.apache.kafka.connect.runtime.Worker:652)
connect-1       | org.apache.kafka.common.KafkaException: Failed to construct kafka producer
connect-1       | 	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:465)
connect-1       | 	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:290)
connect-1       | 	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:273)
connect-1       | 	at org.apache.kafka.connect.runtime.Worker$SourceTaskBuilder.doBuild(Worker.java:1305)
connect-1       | 	at org.apache.kafka.connect.runtime.Worker$TaskBuilder.build(Worker.java:1212)
connect-1       | 	at org.apache.kafka.connect.runtime.Worker.startTask(Worker.java:648)
connect-1       | 	at org.apache.kafka.connect.runtime.Worker.startSourceTask(Worker.java:544)
connect-1       | 	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.startTask(DistributedHerder.java:1756)
connect-1       | 	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.lambda$getTaskStartingCallable$31(DistributedHerder.java:1773)
connect-1       | 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
connect-1       | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
connect-1       | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
connect-1       | 	at java.base/java.lang.Thread.run(Thread.java:833)
connect-1       | Caused by: org.apache.kafka.common.KafkaException: Class io.opentracing.contrib.kafka.TracingProducerInterceptor cannot be found
connect-1       | 	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:398)
connect-1       | 	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstances(AbstractConfig.java:480)
connect-1       | 	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstances(AbstractConfig.java:461)
connect-1       | 	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:396)
connect-1       | 	... 12 more
connect-1       | Caused by: java.lang.ClassNotFoundException: io.opentracing.contrib.kafka.TracingProducerInterceptor
connect-1       | 	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
connect-1       | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
connect-1       | 	at org.apache.kafka.connect.runtime.isolation.PluginClassLoader.loadClass(PluginClassLoader.java:136)
connect-1       | 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
connect-1       | 	at java.base/java.lang.Class.forName0(Native Method)
connect-1       | 	at java.base/java.lang.Class.forName(Class.java:467)
connect-1       | 	at org.apache.kafka.common.utils.Utils.loadClass(Utils.java:422)
connect-1       | 	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:411)
connect-1       | 	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:396)
connect-1       | 	... 15 more
```