### PR TITLE
Update Debezium SQL Server replica README for sqlcmd path changes

### DIFF
--- a/sql-server-read-replica/README.md
+++ b/sql-server-read-replica/README.md
@@ -36,20 +36,20 @@ This demo automatically deploys the topology of services to stream from SQL Serv
 
 ```shell
 # Start the topology with two SQL Servers
-export DEBEZIUM_VERSION=2.1
+export DEBEZIUM_VERSION=3.2
 docker-compose up
 
-# Initialize database and insert test data
-cat debezium-sqlserver-init/inventory.sql | docker exec -i sql-server-read-replica_primary_1 bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD'
+# Initialize database and insert test data 
+cat debezium-sqlserver-init/inventory.sql | docker exec -i sql-server-read-replica-primary-1 bash -c '/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -C'
 
 # Configure primary node and database for replication
-cat debezium-sqlserver-init/setup-primary.sql | docker exec -i sql-server-read-replica_primary_1 bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD'
+cat debezium-sqlserver-init/setup-primary.sql | docker exec -i sql-server-read-replica-primary-1 bash -c '/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -C'
 
 # Configure secondary node to join the cluster
-cat debezium-sqlserver-init/setup-secondary.sql | docker exec -i sql-server-read-replica_secondary_1 bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD'
+cat debezium-sqlserver-init/setup-secondary.sql | docker exec -i sql-server-read-replica-secondary-1 bash -c '/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -C'
 
 # Check that tables are replicated to the secondary node (read-only connection)
-docker-compose exec secondary bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -K readonly -d testDB'
+docker-compose exec secondary bash -c '/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -K readonly -d testDB -C'
 1> SELECT COUNT(*) FROM customers;
 2> GO
            
@@ -70,7 +70,7 @@ docker-compose exec kafka /kafka/bin/kafka-console-consumer.sh \
     --topic server1.testDB.dbo.customers
 
 # Modify records in the primary database via SQL Server client (do not forget to add `GO` command to execute the statement)
-docker-compose exec primary bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -d testDB'
+docker-compose exec primary bash -c '/opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -d testDB -C'
 
 # Shut down the cluster
 docker-compose down


### PR DESCRIPTION

## Description
 This pull request updates the sql-server-read-replica README file in the Debezium SQL Server example to reflect changes in the sqlcmd tool path, add support for self-signed certificates, and upgrade the Debezium version to 3.2.

- sqlcmd Path and Flag Updates:

  Updated sqlcmd commands in the sql-server-read-replica README from `/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD` to` /opt/mssql-tools18/bin/sqlcmd -U sa -P $SA_PASSWORD -C` to match the new sqlcmd tool path.

  Added the `-C` flag to trust self-signed certificates, ensuring compatibility with self-hosted or development environments.
Applied these changes consistently across multiple sqlcmd commands in the sql-server-read-replica README.

- Debezium Version Bump:
Changed the exported variable in the sql-server-read-replica README from export DEBEZIUM_VERSION=2.1 to export DEBEZIUM_VERSION=3.2 to align with the latest stable Debezium release.

- Change the container name to correct name with `'-'` instead of `'_'` in README file. 

## Checklist

- [ ] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file