### PR TITLE
[ai-rag] Add Milvus health check

### DIFF
--- a/ai-rag/docker-compose.yml
+++ b/ai-rag/docker-compose.yml
@@ -20,6 +20,12 @@ services:
       - "19530:19530"
       - "9091:9091"
     command: ["milvus", "run", "standalone"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9091/healthz"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
   ollama:
     image: ollama/ollama
     container_name: ollama
@@ -40,5 +46,7 @@ services:
     volumes:
       - ./config-server:/debezium/config
     depends_on:
-      - milvus
-      - postgres
+      milvus:
+        condition: service_healthy
+      postgres:
+        condition: service_started


### PR DESCRIPTION
It takes some time for Milvus to be fully started and in meantime DBZ server may fail to connect to Milvus, resulting into DBZ server crash.
