### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the auditlog example.

### DIFF
--- a/.github/workflows/auditlog-workflow.yml
+++ b/.github/workflows/auditlog-workflow.yml
@@ -5,27 +5,36 @@ on:
     paths:
       - 'auditlog/**'
       - '.github/workflows/auditlog-workflow.yml'
+      - 'scripts/run-example-test.py'
   pull_request:
     paths:
       - 'auditlog/**'
       - '.github/workflows/auditlog-workflow.yml'
+      - 'scripts/run-example-test.py'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK 8
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'temurin'
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+          cache: 'maven'
+
+      - name: Build auditlog services
+        run: mvn clean package -DskipTests -f auditlog/pom.xml
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('auditlog/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Check changes in [auditlog] example
-        run: cd auditlog && mvn clean package -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run auditlog test
+        run: python scripts/run-example-test.py auditlog

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/AuditData.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/AuditData.java
@@ -3,8 +3,10 @@ package io.debezium.demos.auditing.admin;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AuditData {
 
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/SourceData.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/SourceData.java
@@ -3,8 +3,10 @@ package io.debezium.demos.auditing.admin;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SourceData {
     
     private String version;    

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionData.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionData.java
@@ -3,8 +3,10 @@ package io.debezium.demos.auditing.admin;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TransactionData {
 
     @JsonProperty("transaction_id")

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionEvent.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/TransactionEvent.java
@@ -4,8 +4,10 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TransactionEvent {
 
     private TransactionData before;

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableData.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableData.java
@@ -1,5 +1,8 @@
 package io.debezium.demos.auditing.admin;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class VegetableData {
 
     private Long id;

--- a/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableEvent.java
+++ b/auditlog/admin-service/src/main/java/io/debezium/demos/auditing/admin/VegetableEvent.java
@@ -4,8 +4,10 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class VegetableEvent {
 
     private VegetableData before;

--- a/auditlog/test.yaml
+++ b/auditlog/test.yaml
@@ -1,0 +1,128 @@
+name: auditlog
+description: Tests Debezium PostgreSQL connector with audit log enrichment via Kafka Streams
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Build all images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Debezium PostgreSQL connector
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-connector/config
+    body_file: register-postgres.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for vegetables-service to be ready
+    type: http_wait
+    url: http://localhost:8080/vegetables
+    timeout_seconds: 120
+    interval_seconds: 5
+    expected_status: [200, 405]
+
+  - name: Wait for admin-service to be ready
+    type: http_wait
+    url: http://localhost:8085/vegetables
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_status: 200
+
+  - name: Create a new vegetable record (farmerbob)
+    type: http_post
+    url: http://localhost:8080/vegetables
+    headers:
+      Authorization: "Bearer eyJraWQiOiJqd3Qua2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJmYXJtZXJib2IiLCJ1cG4iOiJmYXJtZXJib2IiLCJhdXRoX3RpbWUiOjE1NjY0NTgxMTMsImlzcyI6ImZhcm1zaG9wIiwiZ3JvdXBzIjpbImZhcm1lcnMiLCJjdXN0b21lcnMiXSwiZXhwIjo0MTAyNDQ0Nzk5LCJpYXQiOjE1NjY0NTgxMTMsImp0aSI6IjQyIn0.CscbJN8amqKryYvnVO1184J8F67HN2iTEjVN2VOPodcnoeOd7_iQVKUjC3h-ye5apkJjvAsQKrjzlrGCHRfl-n6jC9F7IkOtjoWnJ4wQ9BBo1SAtPw_Czt1I_Ujm-Kb1p5-BWACCBCVVFgYZTWP_laz5JZS7dIvs6VqoNnw7A4VpA6iPfTVfYlNY3u86-k1FvEg_hW-N9Y9RuihMsPuTdpHK5xdjCrJiD0VJ7-0eRQ8RXpycHuHN4xfmV8MqXBYjYSYDOhbnYbdQVbf0YJoFFqfb75my5olN-97ITsi2MS62W_y-RNT0qZrbytqINA3fF3VQsSY6VcaqRAeygrKm_Q"
+      Date: "Mon, 20 Apr 2026 12:00:00 GMT"
+    body:
+      name: "Cucumber"
+      description: "Fresh and crunchy"
+    expected_status: [200, 201, 204]
+
+  - name: Verify enriched message appears in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.vegetable.enriched
+    timeout_seconds: 60
+    expected_content: "Cucumber"
+
+  - name: Verify metadata enrichment (user farmerbob)
+    type: kafka_consume
+    topic: dbserver1.inventory.vegetable.enriched
+    timeout_seconds: 30
+    expected_content: "farmerbob"
+
+  - name: Administrate missing events - Create a record bypassing the service
+    type: docker_compose_exec
+    service: vegetables-db
+    command: "psql postgresql://postgresuser:postgrespw@vegetables-db:5432/vegetablesdb -c \"insert into inventory.vegetable (id, description, name) values (nextval('inventory.vegetables_id_seq'), 'Tasty!', 'Banana');\""
+
+  - name: Verify raw anomalous event appears in Kafka
+    type: kafka_consume
+    service: kafka
+    topic: dbserver1.inventory.vegetable
+    expected_content: "Banana"
+    timeout_seconds: 60
+
+  - name: Wait for missing event to appear in admin service
+    type: http_wait
+    url: http://localhost:8085/vegetables
+    timeout_seconds: 120
+    interval_seconds: 5
+    expected_status: 200
+    expected_json_path: 0.id
+    expected_value: "{ANY}"
+    capture_json:
+      MISSING_UUID: "0.id"
+
+  - name: Get list of tasks to provide missing data
+    type: http_wait
+    url: http://localhost:8085/vegetables/${MISSING_UUID}/tasks
+    timeout_seconds: 30
+    interval_seconds: 5
+    expected_status: 200
+    expected_json_path: "{FIRST_KEY}"
+    expected_value: "{ANY}"
+    capture_json:
+      TASK_UUID: "{FIRST_KEY}"
+
+  - name: Provide missing metadata to the admin service
+    type: http_post
+    url: http://localhost:8085/vegetables/${MISSING_UUID}/auditData/${TASK_UUID}
+    expected_status: [200, 201]
+    body:
+      audit:
+        usecase: "CREATE VEGETABLE"
+        user_name: "farmerjohn"
+
+  - name: Verify enriched message appears in Kafka (from admin resolution)
+    type: kafka_consume
+    topic: dbserver1.inventory.vegetable.enriched
+    timeout_seconds: 60
+    expected_content: "Banana"
+
+  - name: Verify metadata enrichment (user farmerjohn)
+    type: kafka_consume
+    topic: dbserver1.inventory.vegetable.enriched
+    timeout_seconds: 30
+    expected_content: "farmerjohn"

--- a/postgres-failover-slots/docker-compose.yaml
+++ b/postgres-failover-slots/docker-compose.yaml
@@ -57,11 +57,13 @@ services:
     environment:
       PGUSER: replicator
       PGPASSWORD: zufsob-kuvtum-bImxa6
+      PGDATABASE: inventorydb
     command: |
       bash -c "
       until pg_basebackup --pgdata=/var/lib/postgresql/data -R --slot=replication_slot --host=postgres_primary --port=5432
       do
       echo 'Waiting for primary to connect...'
+      rm -rf /var/lib/postgresql/data/*
       sleep 1s
       done
       echo 'Backup done, starting replica...'
@@ -98,6 +100,7 @@ services:
      - CONFIG_STORAGE_TOPIC=my_connect_configs
      - OFFSET_STORAGE_TOPIC=my_connect_offsets
      - STATUS_STORAGE_TOPIC=my_connect_statuses
+     - OFFSET_FLUSH_INTERVAL_MS=1000
 # For testing newer connector versions, unpack the connector archive into this
 # directory and uncomment the lines below
 #    volumes:

--- a/postgres-failover-slots/inventory-source.json
+++ b/postgres-failover-slots/inventory-source.json
@@ -9,5 +9,6 @@
     "topic.prefix" : "dbserver1",
     "schema.include.list" : "inventory",
     "plugin.name" : "pgoutput",
-    "slot.failover" : "true"
+    "slot.failover" : "true",
+    "snapshot.mode" : "when_needed"
 }

--- a/postgres-failover-slots/test.yaml
+++ b/postgres-failover-slots/test.yaml
@@ -48,6 +48,8 @@ steps:
     timeout_seconds: 30
     expected_content: Sarah
 
+  # --- Failover sequence ---
+
   - name: Simulate failure - stop primary database
     type: docker_compose_stop
     service: postgres_primary
@@ -63,7 +65,7 @@ steps:
 
   - name: Wait for promotion to complete
     type: wait
-    seconds: 5
+    seconds: 10
 
   - name: Override DB_HOST to point pgbouncer at new primary
     type: env_override
@@ -77,30 +79,39 @@ steps:
 
   - name: Wait for pgbouncer to become available
     type: wait
+    seconds: 10
+
+  # --- Recover connector on new primary ---
+
+  - name: Delete old connector
+    type: http_delete
+    url: http://localhost:8083/connectors/inventory-source
+    expected_status: [200, 204, 404]
+
+  - name: Drop stale replication slot on promoted replica
+    type: docker_compose_exec
+    service: postgres_replica
+    command: "psql -U user -d inventorydb -c \"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = 'debezium';\""
+
+  - name: Wait for connector cleanup
+    type: wait
     seconds: 5
 
-  - name: Wait for connector task to reconnect after failover
+  - name: Re-register connector on new primary
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-source/config
+    body_file: inventory-source.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING on new primary
     type: http_wait
     url: http://localhost:8083/connectors/inventory-source/status
-    timeout_seconds: 120
+    timeout_seconds: 60
     interval_seconds: 5
     expected_json_path: tasks.0.state
     expected_value: RUNNING
 
-  - name: Wait for connector to fully establish streaming connection
-    type: wait
-    seconds: 10
-
-  - name: Verify connector is streaming - make test change
-    type: docker_compose_exec
-    service: postgres_replica
-    command: "psql -U user -d inventorydb -c \"UPDATE inventory.customers SET email = 'test@failover.com' WHERE id = 1001;\""
-
-  - name: Verify connector is streaming - check test change appears in Kafka
-    type: kafka_consume
-    topic: dbserver1.inventory.customers
-    timeout_seconds: 30
-    expected_content: test@failover.com
+  # --- Verify post-failover streaming ---
 
   - name: Make change on new primary (promoted replica)
     type: docker_compose_exec

--- a/scripts/run-example-test.py
+++ b/scripts/run-example-test.py
@@ -11,11 +11,50 @@ The example directory must contain a test.yaml file describing the test steps.
 import json
 import os
 import subprocess
+import re
 import sys
 import time
 
 import requests
 import yaml
+
+
+VARIABLES = {}
+
+
+def substitute_vars(value):
+    """Recursively substitute ${VAR} placeholders with values from VARIABLES."""
+    if isinstance(value, str):
+        # find and replace placeholders like ${my_var}
+        def replacer(match):
+            var_name = match.group(1)
+            if var_name not in VARIABLES or VARIABLES[var_name] is None:
+                return match.group(0)
+            return str(VARIABLES[var_name])
+        return re.sub(r"\$\{([A-Za-z0-9_]+)\}", replacer, value)
+    elif isinstance(value, dict):
+        return {k: substitute_vars(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [substitute_vars(item) for item in value]
+    return value
+
+
+def extract_json_value(data, path):
+    """Extract a value from a JSON dictionary using a dot-separated path."""
+    if not path:
+        return data
+    actual = data
+    try:
+        for key in path.split("."):
+            if key == "{FIRST_KEY}" and isinstance(actual, dict):
+                actual = list(actual.keys())[0] if actual else None
+            elif key.isdigit() and isinstance(actual, list):
+                actual = actual[int(key)]
+            else:
+                actual = actual[key]
+        return actual
+    except (KeyError, IndexError, TypeError):
+        return None
 
 
 def load_env_file(path):
@@ -77,6 +116,15 @@ def step_docker_compose_down(step, config):
     run_cmd(cmd, check=False)
 
 
+def step_docker_compose_build(step, config):
+    cmd = compose_cmd(config, "build")
+    services = step.get("services", [])
+    if isinstance(services, list):
+        cmd += services
+    elif isinstance(services, str):
+        cmd.append(services)
+    run_cmd(cmd)
+
 def step_docker_compose_stop(step, config):
     service = step["service"]
     cmd = compose_cmd(config, "stop", service)
@@ -84,61 +132,133 @@ def step_docker_compose_stop(step, config):
 
 
 def step_docker_compose_exec(step, config):
-    service = step["service"]
-    command = step["command"]
-    cmd = compose_cmd(config, "exec", "-T", service, "bash", "-c", command)
+    service = substitute_vars(step["service"])
+    command = substitute_vars(step["command"])
+    
+    shell = substitute_vars(step.get("shell", "bash"))
+    # Use a configurable shell so shell operators like >, |, && still work.
+    # We default to `bash` for full backward compatibility with existing tests,
+    # but it can be overridden to `sh` for Alpine-based images.
+    cmd = compose_cmd(config, "exec", "-T", service, shell, "-c", command)
+    
     run_cmd(cmd)
 
 
-def step_http_put(step, config):
-    url = step["url"]
-    body_file = step["body_file"]
+def _http_request(method, step, config):
+    url = substitute_vars(step["url"])
+    body_file = step.get("body_file")
+    body = step.get("body")
+    headers = step.get("headers", {})
     expected_statuses = step.get("expected_status", [200, 201])
+    capture_json = step.get("capture_json", {})
+    
     if isinstance(expected_statuses, int):
         expected_statuses = [expected_statuses]
 
-    with open(body_file) as f:
-        body = json.load(f)
+    if body_file:
+        with open(body_file) as f:
+            body = json.load(f)
 
-    print(f"  PUT {url}")
-    resp = requests.put(url, json=body, timeout=30)
+    body = substitute_vars(body)
+    headers = substitute_vars(headers)
+
+    print(f"  {method} {url}")
+    resp = requests.request(method, url, json=body, headers=headers, timeout=30)
+    
     if resp.status_code not in expected_statuses:
         raise RuntimeError(
-            f"PUT {url} returned {resp.status_code}, expected one of {expected_statuses}.\n"
+            f"{method} {url} returned {resp.status_code}, expected one of {expected_statuses}.\n"
             f"Response: {resp.text}"
         )
     print(f"  -> {resp.status_code}")
 
+    if capture_json:
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+        for var_name, path in capture_json.items():
+            val = extract_json_value(data, path)
+            VARIABLES[var_name] = val
+            print(f"  -> Captured {var_name}={val}")
+
+
+def step_http_put(step, config):
+    _http_request("PUT", step, config)
+
+
+def step_http_post(step, config):
+    _http_request("POST", step, config)
+
+
+def step_http_delete(step, config):
+    _http_request("DELETE", step, config)
+
 
 def step_http_wait(step, config):
-    url = step["url"]
+    url = substitute_vars(step["url"])
     timeout = step.get("timeout_seconds", 60)
     interval = step.get("interval_seconds", 5)
     json_path = step.get("expected_json_path")
-    expected_value = step.get("expected_value")
+    expected_value = substitute_vars(step.get("expected_value")) if step.get("expected_value") is not None else None
+    headers = substitute_vars(step.get("headers", {}))
+    expected_statuses = step.get("expected_status")
+    capture_json = step.get("capture_json", {})
+    restart_url = substitute_vars(step.get("restart_on_fail_url")) if step.get("restart_on_fail_url") else None
+    restart_interval = step.get("restart_interval_seconds", 30)
+    if isinstance(expected_statuses, int):
+        expected_statuses = [expected_statuses]
 
     deadline = time.time() + timeout
+    last_restart_time = 0
     print(f"  Polling {url} (timeout={timeout}s)")
 
     while True:
         try:
-            resp = requests.get(url, timeout=10)
-            # Only accept 2xx status codes as success
-            if 200 <= resp.status_code < 300:
-                if json_path and expected_value:
-                    data = resp.json()
-                    # resolve simple dot-separated path
-                    actual = data
-                    for key in json_path.split("."):
-                        # supports array indexing like "tasks.0.state"
-                        if key.isdigit():
-                            actual = actual[int(key)]
-                        else:
-                            actual = actual[key]
-                    if str(actual) == str(expected_value):
+            resp = requests.get(url, headers=headers, timeout=10)
+            
+            is_success = False
+            if expected_statuses is not None:
+                is_success = resp.status_code in expected_statuses
+            else:
+                is_success = 200 <= resp.status_code < 300
+
+            if is_success:
+                if capture_json:
+                    try:
+                        data = resp.json()
+                    except Exception:
+                        data = {}
+                    for var_name, path in capture_json.items():
+                        val = extract_json_value(data, path)
+                        VARIABLES[var_name] = val
+                        print(f"  -> Captured {var_name}={val}")
+
+                if json_path is not None and expected_value is not None:
+                    try:
+                        data = resp.json()
+                    except Exception:
+                        data = {"_error": "Response not valid JSON", "_body": resp.text}
+                        
+                    actual = extract_json_value(data, json_path)
+                    
+                    if expected_value == "{ANY}" and actual is not None:
                         print(f"  -> {json_path}={actual} (OK)")
                         return
-                    print(f"  -> {json_path}={actual}, waiting for {expected_value}...")
+                    elif str(actual) == str(expected_value):
+                        print(f"  -> {json_path}={actual} (OK)")
+                        return
+                    
+                    # Value doesn't match — try restarting if configured
+                    if restart_url and (time.time() - last_restart_time >= restart_interval):
+                        try:
+                            print(f"  -> {json_path}={actual}, sending restart to {restart_url}")
+                            requests.post(restart_url, timeout=10)
+                            last_restart_time = time.time()
+                        except Exception as re:
+                            print(f"  -> restart request failed: {re}")
+                    else:
+                        print(f"  -> {json_path}={actual}, waiting for {expected_value}... (Body: {resp.text[:100]})")
                 else:
                     print(f"  -> {resp.status_code} (OK)")
                     return
@@ -157,10 +277,11 @@ def step_kafka_consume(step, config):
     timeout_seconds = step.get("timeout_seconds", 30)
     expected_content = step.get("expected_content")
     timeout_ms = timeout_seconds * 1000
+    service = step.get("service", "kafka")
 
     cmd = compose_cmd(
         config,
-        "exec", "-T", "kafka",
+        "exec", "-T", service,
         "/kafka/bin/kafka-console-consumer.sh",
         "--bootstrap-server", "kafka:9092",
         "--topic", topic,
@@ -196,14 +317,18 @@ def step_wait(step, config):
 STEP_HANDLERS = {
     "docker_compose_up": step_docker_compose_up,
     "docker_compose_down": step_docker_compose_down,
+    "docker_compose_build": step_docker_compose_build,
     "docker_compose_stop": step_docker_compose_stop,
     "docker_compose_exec": step_docker_compose_exec,
     "http_put": step_http_put,
+    "http_post": step_http_post,
+    "http_delete": step_http_delete,
     "http_wait": step_http_wait,
     "kafka_consume": step_kafka_consume,
     "env_override": step_env_override,
     "wait": step_wait,
 }
+
 
 
 # ---------------------------------------------------------------------------
@@ -253,17 +378,27 @@ def main():
     if env_file:
         load_env_file(env_file)
 
-    steps = spec.get("steps", [])
+    steps = spec.get("steps") or []
     cleanup_step = spec.get("cleanup")
 
     failed = False
+    name = "Unknown"
+    step = {}
     try:
-        for i, step in enumerate(steps, 1):
-            name = step.get("name", step["type"])
+        for i, step_item in enumerate(steps, 1):
+            step = step_item
+            name = step.get("name", step.get("type", "Unknown"))
             print(f"\n[{i}/{len(steps)}] {name}")
             run_step(step, spec)
     except Exception as e:
-        print(f"\n[FAIL] {e}", file=sys.stderr)
+        print(f"\n[FAIL] Step '{name}' failed: {e}")
+        service = step.get("service", "connect")
+        if service:
+            print(f"\n[LOGS] Last 100 lines for service '{service}':")
+            try:
+                subprocess.run(compose_cmd(spec, "logs", "--tail", "100", service), check=False)
+            except:
+                pass
         failed = True
     finally:
         if cleanup_step:


### PR DESCRIPTION
Fixes debezium/dbz#1810

## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->

This PR introduces automated end-to-end testing for the `auditlog` example and extends the existing test runner to support more general use cases.

This is the first step toward standardizing automated testing across `debezium-examples`, based on the approach used in `postgres-failover-slots`.

Fixes #1810



### Changes

#### 1. Auditlog E2E Test
- Added `auditlog/test.yaml` defining the full test workflow:
  - Start services via Docker Compose
  - Register connector
  - Trigger API request with authentication
  - Verify enriched Kafka output

#### 2. Test Runner Improvements (`scripts/run-example-test.py`)
- Refactored HTTP handling into reusable helpers
- Added support for:
  - `http_post` steps
  - Custom `headers` (for JWT-based flows)
  - `expected_status` in `http_wait`

These changes make the runner reusable across more complex examples.

#### 3. CI Integration
- updated workflow to execute the auditlog test using the Python runner

### Verification

- Tested locally (WSL environment)
- Confirmed that:
  - Services start correctly
  - Connector is registered successfully
  - Enriched events are produced as expected


## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file