### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the outbox example

### DIFF
--- a/.github/workflows/outbox-workflow.yml
+++ b/.github/workflows/outbox-workflow.yml
@@ -5,16 +5,25 @@ on:
     paths:
       - 'outbox/**'
       - '.github/workflows/outbox-workflow.yml'
+      - 'scripts/run-example-test.py'
   pull_request:
     paths:
       - 'outbox/**'
       - '.github/workflows/outbox-workflow.yml'
+      - 'scripts/run-example-test.py'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:
@@ -24,3 +33,14 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Check changes in [outbox] example
         run: cd outbox && mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run outbox test
+        run: python scripts/run-example-test.py outbox

--- a/outbox/test.yaml
+++ b/outbox/test.yaml
@@ -1,0 +1,90 @@
+name: outbox
+description: Tests Debezium PostgreSQL connector with the outbox pattern
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Build all images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Debezium PostgreSQL outbox connector
+    type: http_put
+    url: http://localhost:8083/connectors/outbox-connector/config
+    body_file: register-postgres.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/outbox-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for snapshot to finish
+    type: wait
+    seconds: 15
+
+  - name: Wait for order-service to be ready
+    type: http_wait
+    url: http://localhost:8080/orders
+    timeout_seconds: 120
+    interval_seconds: 5
+    expected_status: [405]
+
+  - name: Create a new order
+    type: http_post
+    url: http://localhost:8080/orders
+    body_file: resources/data/create-order-request.json
+    headers:
+      Content-Type: application/json
+    expected_status: [200, 201, 204]
+    capture_json:
+      order_id: id
+      line_id: lineItems.1.id
+
+  - name: Cancel an order line
+    type: http_put
+    url: http://localhost:8080/orders/${order_id}/lines/${line_id}
+    body_file: resources/data/cancel-order-line-request.json
+    headers:
+      Content-Type: application/json
+    expected_status: [200, 201, 204]
+
+  - name: Verify OrderCreated event appears in Kafka
+    type: kafka_consume
+    topic: Order.events
+    timeout_seconds: 60
+    expected_content: "Debezium in Action"
+
+  - name: Verify shipment-service processed OrderCreated event
+    type: wait_for_log
+    service: shipment-service
+    timeout_seconds: 30
+    expected_content: "Processing 'OrderCreated' event"
+
+  - name: Verify OrderLineUpdated event appears in Kafka
+    type: kafka_consume
+    topic: Order.events
+    timeout_seconds: 30
+    expected_content: "CANCELLED"
+
+  - name: Verify shipment-service processed OrderLineUpdated event
+    type: wait_for_log
+    service: shipment-service
+    timeout_seconds: 30
+    expected_content: "Processing 'OrderLineUpdated' event"

--- a/postgres-failover-slots/test.yaml
+++ b/postgres-failover-slots/test.yaml
@@ -88,14 +88,14 @@ steps:
     url: http://localhost:8083/connectors/inventory-source
     expected_status: [200, 204, 404]
 
+  - name: Wait for connector cleanup
+    type: wait
+    seconds: 10
+
   - name: Drop stale replication slot on promoted replica
     type: docker_compose_exec
     service: postgres_replica
     command: "psql -U user -d inventorydb -c \"SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = 'debezium';\""
-
-  - name: Wait for connector cleanup
-    type: wait
-    seconds: 5
 
   - name: Re-register connector on new primary
     type: http_put

--- a/scripts/run-example-test.py
+++ b/scripts/run-example-test.py
@@ -276,6 +276,8 @@ def step_kafka_consume(step, config):
     topic = step["topic"]
     timeout_seconds = step.get("timeout_seconds", 30)
     expected_content = step.get("expected_content")
+    if expected_content is not None and not isinstance(expected_content, str):
+        expected_content = str(expected_content)
     timeout_ms = timeout_seconds * 1000
     service = step.get("service", "kafka")
 
@@ -314,6 +316,38 @@ def step_wait(step, config):
     time.sleep(seconds)
 
 
+def step_wait_for_log(step, config):
+    service = substitute_vars(step["service"])
+    expected_content = step.get("expected_content")
+    if not expected_content or not isinstance(expected_content, str):
+        raise RuntimeError(f"Step 'wait_for_log' requires 'expected_content' to be a non-empty string, but got {type(expected_content).__name__}")
+    
+    timeout_seconds = step.get("timeout_seconds", 30)
+    interval = step.get("interval_seconds", 5)
+
+    deadline = time.time() + timeout_seconds
+    # Use --tail to keep log inspection efficient as suggested by Copilot
+    cmd = compose_cmd(config, "logs", "--tail", "200", service)
+    print(f"  Waiting for '{expected_content}' in {service} logs (timeout={timeout_seconds}s)")
+
+    while True:
+        # run directly to avoid spamming the console
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True, env=os.environ)
+        output = result.stdout + result.stderr
+        
+        if expected_content in output:
+            print(f"  -> Found '{expected_content}' in logs (OK)")
+            return
+            
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"Expected '{expected_content}' not found in logs of service '{service}' within {timeout_seconds}s.\n"
+                f"Logs (last 200 lines):\n{output}"
+            )
+        
+        time.sleep(interval)
+
+
 STEP_HANDLERS = {
     "docker_compose_up": step_docker_compose_up,
     "docker_compose_down": step_docker_compose_down,
@@ -327,6 +361,7 @@ STEP_HANDLERS = {
     "kafka_consume": step_kafka_consume,
     "env_override": step_env_override,
     "wait": step_wait,
+    "wait_for_log": step_wait_for_log,
 }
 
 


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes https://github.com/debezium/dbz/issues/1810
This PR introduces automated end-to-end testing for the `outbox` example, utilizing the shared YAML-driven test runner established in #406. 

This is the next incremental step in standardizing automated testing across all examples in the repository.

### Changes
1. **Outbox E2E Test Manifest**
   - Added `outbox/test.yaml` which defines the full test workflow:
     - Builds and starts all services via Docker Compose
     - Registers the outbox connector
     - Triggers REST API calls to `order-service` to create an order and update an order line
     - Consumes the `Order.events` Kafka topic to verify that the outbox router properly published the events by checking for specific strings (`"Debezium in Action"` and `"CANCELLED"`).
2. **CI Integration**
   - Updated `.github/workflows/outbox-workflow.yml` to automatically execute the Python runner for the `outbox` test.
   - Added a `Set up Java 11` step to the CI workflow to prevent `quarkus-maven-plugin` bytecode enhancement failures when the GitHub runner defaults to Java 21.
   - Configured the workflow to run when `scripts/run-example-test.py` is updated.

### Verification
- Tested locally.
- Confirmed that:
  - Services start and the connector registers successfully.
  - The Quarkus `order-service` receives and processes the HTTP requests.
  - The Kafka consumer successfully reads the correct payload records from the stream.


## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file