### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the mongodb-outbox example

### DIFF
--- a/mongodb-outbox/docker-compose.yaml
+++ b/mongodb-outbox/docker-compose.yaml
@@ -1,12 +1,4 @@
 services:
-  jaeger:
-    image: jaegertracing/all-in-one:1
-    ports:
-      - 6831:6831/udp
-      - 16686:16686
-    networks:
-      - my-network
-
   kafka:
     image: quay.io/debezium/kafka:${DEBEZIUM_VERSION}
     ports:
@@ -52,13 +44,10 @@ services:
         config.storage.replication.factor=1
         status.storage.topic=connect-status
         status.storage.replication.factor=1
-        consumer.interceptor.classes=io.opentracing.contrib.kafka.TracingConsumerInterceptor
-        producer.interceptor.classes=io.opentracing.contrib.kafka.TracingProducerInterceptor
-      - JAEGER_SERVICE_NAME=kafka-connect
-      - JAEGER_AGENT_HOST=jaeger
-      - JAEGER_SAMPLER_TYPE=const
-      - JAEGER_SAMPLER_PARAM=1
-      - STRIMZI_TRACING=jaeger
+      - OTEL_SERVICE_NAME=kafka-connect
+      - OTEL_TRACES_EXPORTER=none
+      - OTEL_METRICS_EXPORTER=none
+      - STRIMZI_TRACING=opentelemetry
       - BOOTSTRAP_SERVERS=kafka:9092
       - GROUP_ID=1
       - CONFIG_STORAGE_TOPIC=my_connect_configs

--- a/mongodb-outbox/test.yaml
+++ b/mongodb-outbox/test.yaml
@@ -1,0 +1,54 @@
+name: mongodb-outbox
+description: Tests Debezium MongoDB connector with the Outbox pattern
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Build all images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Debezium MongoDB connector
+    type: http_post
+    url: http://localhost:8083/connectors/
+    body_file: register-mongodb.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/outbox-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Insert order and outbox event via MongoDB
+    type: docker_compose_exec
+    service: mongodb
+    command: >
+      mongosh -u $MONGODB_USER -p $MONGODB_PASSWORD --authenticationDatabase admin inventory --eval '
+      new_order = { "_id" : ObjectId("000000000000000000000001"), "order_date" : ISODate("2021-11-22T00:00:00Z"), "purchaser_id" : NumberLong(1004), "quantity" : 1, "product_id" : NumberLong(107) };
+      s = db.getMongo().startSession();
+      s.startTransaction();
+      s.getDatabase("inventory").orders.insertOne(new_order);
+      s.getDatabase("inventory").outboxevent.insertOne({ aggregateid : new_order._id, aggregatetype : "Order", type : "OrderCreated", timestamp: NumberLong(1556890294484), payload : new_order });
+      s.commitTransaction();'
+
+  - name: Verify outbox event appears in Kafka
+    type: kafka_consume
+    topic: Order.events
+    timeout_seconds: 60
+    expected_content: "purchaser_id=1004"


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the `mongodb-outbox` example, utilizing the shared YAML-driven test runner established in #406.

### Changes
* **MongoDB Outbox E2E Test Manifest**: Added `mongodb-outbox/test.yaml` which defines the full test workflow:
  * Builds and starts all services via Docker Compose.
  * Registers the MongoDB outbox connector.
  * Executes a multi-document transaction using `mongosh` to insert an order and outbox event simultaneously.
  * Consumes the `Order.events` Kafka topic to verify that the Debezium outbox router properly expanded and published the event payload.
* **Docker Compose Fix**: Removed deprecated OpenTracing interceptors from `mongodb-outbox/docker-compose.yaml` to prevent a `ClassNotFoundException` that was causing the connector task to crash on startup in modern images.

### Verification
* Tested locally via `python3 scripts/run-example-test.py mongodb-outbox`.
* Confirmed that the services start, the transaction executes successfully, and the Kafka consumer reads the correct expanded payload.


## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file