### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the mysql tutorial example

### DIFF
--- a/tutorial/test.yaml
+++ b/tutorial/test.yaml
@@ -1,0 +1,44 @@
+name: mysql-tutorial
+description: Tests Debezium MySQL connector via the official tutorial setup
+env_file: ../.env
+compose_file: docker-compose-mysql.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Debezium MySQL connector
+    type: http_post
+    url: http://localhost:8083/connectors/
+    body_file: register-mysql.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Make change in MySQL database
+    type: docker_compose_exec
+    service: mysql
+    command: "mysql -u mysqluser -pmysqlpw inventory -e \"UPDATE customers SET first_name = 'Sarah' WHERE id = 1001;\""
+
+  - name: Verify change appears in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "Sarah"


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the standard MySQL flow in the `tutorial` example, utilizing the shared YAML-driven test runner established in #406.

### Changes
* **Tutorial E2E Test Manifest**: Added `tutorial/test.yaml` which defines the test workflow:
  * Starts the services via `docker-compose-mysql.yaml`.
  * Registers the MySQL connector using `register-mysql.json`.
  * Executes a database update query on the `inventory.customers` table using the MySQL client.
  * Consumes the `dbserver1.inventory.customers` Kafka topic to verify that the CDC event was successfully captured and streamed.

### Verification
* Tested locally via `python3 scripts/run-example-test.py tutorial`.
* Confirmed that the connector registers successfully and the `UPDATE` operation is successfully published to Kafka.


## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file