### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the postgres-toast example

### DIFF
--- a/.github/workflows/postgres-toast-workflow.yml
+++ b/.github/workflows/postgres-toast-workflow.yml
@@ -5,16 +5,25 @@ on:
     paths:
       - 'postgres-toast/**'
       - '.github/workflows/postgres-toast-workflow.yml'
+      - 'scripts/run-example-test.py'
   pull_request:
     paths:
       - 'postgres-toast/**'
       - '.github/workflows/postgres-toast-workflow.yml'
+      - 'scripts/run-example-test.py'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
       - name: Cache local Maven repository
         uses: actions/cache@v4
         with:
@@ -22,5 +31,17 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('postgres-toast/**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
       - name: Check changes in [postgres-toast] example
         run: cd postgres-toast && mvn clean install -f toast-value-store/pom.xml -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run postgres-toast test
+        run: python scripts/run-example-test.py postgres-toast

--- a/postgres-toast/test.yaml
+++ b/postgres-toast/test.yaml
@@ -1,0 +1,72 @@
+name: postgres-toast
+description: Tests Debezium PostgreSQL connector dealing with TOAST column values and stateful Kafka Streams enrichment
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Build all images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Debezium Postgres source connector
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-connector/config
+    body_file: debezium-source.json
+    expected_status: [200, 201]
+
+  - name: Register JDBC sink connector
+    type: http_put
+    url: http://localhost:8083/connectors/sink-connector/config
+    body_file: jdbc-sink.json
+    expected_status: [200, 201]
+
+  - name: Wait for source connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for sink connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/sink-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Update customer first name in source database
+    type: docker_compose_exec
+    service: source-db
+    command: 'psql postgresql://postgresusersource:postgrespw@source-db:5432/sourcedb -c "UPDATE inventory.customers SET first_name = ''Dana'' WHERE id = 1001;"'
+
+  - name: Verify update appears in Kafka customers topic
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "Dana"
+
+  - name: Update product description in source database (TOAST trigger test)
+    type: docker_compose_exec
+    service: source-db
+    command: 'psql postgresql://postgresusersource:postgrespw@source-db:5432/sourcedb -c "UPDATE inventory.products SET description = ''Much wow'' WHERE id = 101;"'
+
+  - name: Verify enriched product event appears in enriched Kafka topic
+    type: kafka_consume
+    topic: dbserver1.inventory.products.enriched
+    timeout_seconds: 60
+    expected_content: "Much wow"


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the `postgres-toast` example, utilizing the shared YAML-driven test runner established in #406.

### Changes
* **PostgreSQL TOAST E2E Test Manifest**: Added `postgres-toast/test.yaml` which defines the full test workflow:
  * Builds and starts all services via Docker Compose (Source DB, Sink DB, Kafka Connect, Kafka, and the `toast-value-store` Streams application).
  * Registers the PostgreSQL source connector and the Confluent JDBC sink connector.
  * Modifies a customer's first name in the source database and verifies the change propagates to the `dbserver1.inventory.customers` Kafka topic.
  * Modifies a product's description in the source database to trigger a TOAST replication event and verifies that the stateful Quarkus Streams application (`toast-value-store`) enriches and publishes the event successfully to the `dbserver1.inventory.products.enriched` Kafka topic.
* **CI Workflow**: Updated `.github/workflows/postgres-toast-workflow.yml` to:
  * Build the Quarkus Streams application (`mvn clean install -f toast-value-store/pom.xml`) prior to the test execution.
  * Set up Python 3.11, install dependencies (`pyyaml` and `requests`), and run the test runner script against the `postgres-toast` example.

### Verification
* Verified compiling the Streams application successfully.
* Created the test manifest and verified the GitHub Actions workflow definition is correctly formatted.

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file
