### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the cloudevents example

### DIFF
--- a/.github/workflows/cloudevents.yml
+++ b/.github/workflows/cloudevents.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths:
       - 'cloudevents/**'
-      - '.github/workflows/cloudevents-workflow.yml'
+      - '.github/workflows/cloudevents.yml'
+      - 'scripts/run-example-test.py'
   pull_request:
     paths:
       - 'cloudevents/**'
-      - '.github/workflows/cloudevents-workflow.yml'
+      - '.github/workflows/cloudevents.yml'
+      - 'scripts/run-example-test.py'
 
 jobs:
   build:
@@ -29,3 +31,14 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Check changes in [cloudevents] example
         run: cd cloudevents && mvn clean install -f avro-data-extractor/pom.xml -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run cloudevents test
+        run: python scripts/run-example-test.py cloudevents

--- a/.github/workflows/outbox-workflow.yml
+++ b/.github/workflows/outbox-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Cache local Maven repository

--- a/.github/workflows/postgres-toast-workflow.yml
+++ b/.github/workflows/postgres-toast-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Cache local Maven repository

--- a/cloudevents/avro-data-extractor/Dockerfile
+++ b/cloudevents/avro-data-extractor/Dockerfile
@@ -1,5 +1,13 @@
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS='-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=${PORT}'
-COPY target/lib/* /deployments/lib/
-COPY target/*-runner.jar /deployments/app.jar
-ENTRYPOINT [ "/deployments/run-java.sh" ]
+FROM eclipse-temurin:21-jre
+
+ENV PORT=8079
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0"
+
+COPY target/quarkus-app/lib/ /deployments/lib/
+COPY target/quarkus-app/*.jar /deployments/
+COPY target/quarkus-app/app/ /deployments/app/
+COPY target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8079
+
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTIONS -Dquarkus.http.port=${PORT} -jar /deployments/quarkus-run.jar" ]

--- a/cloudevents/register-postgres-avro-avro.json
+++ b/cloudevents/register-postgres-avro-avro.json
@@ -6,7 +6,7 @@
     "database.user": "postgres",
     "database.password": "postgres",
     "database.dbname" : "postgres",
-    "database.server.name": "dbserver3",
+    "topic.prefix": "dbserver3",
     "slot.name":"dbserver3",
     "schema.include.list": "inventory",
     "key.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/cloudevents/register-postgres-json-avro.json
+++ b/cloudevents/register-postgres-json-avro.json
@@ -6,7 +6,7 @@
     "database.user": "postgres",
     "database.password": "postgres",
     "database.dbname" : "postgres",
-    "database.server.name": "dbserver2",
+    "topic.prefix": "dbserver2",
     "slot.name":"dbserver2",
     "schema.include.list": "inventory",
     "key.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/cloudevents/register-postgres-json-json.json
+++ b/cloudevents/register-postgres-json-json.json
@@ -6,7 +6,7 @@
     "database.user": "postgres",
     "database.password": "postgres",
     "database.dbname" : "postgres",
-    "database.server.name": "dbserver1",
+    "topic.prefix": "dbserver1",
     "slot.name":"dbserver1",
     "schema.include.list": "inventory",
     "key.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/cloudevents/test.yaml
+++ b/cloudevents/test.yaml
@@ -1,0 +1,50 @@
+name: cloudevents
+description: Tests Debezium PostgreSQL connector with CloudEvents structured mode (JSON format)
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Build all images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Register Postgres connector
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-connector-json-json/config
+    body_file: register-postgres-json-json.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector-json-json/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Modify records in Postgres database
+    type: docker_compose_exec
+    service: postgres
+    command: 'psql postgresql://postgres:postgres@localhost:5432/postgres -c "UPDATE inventory.customers SET first_name = ''Sarah'' WHERE id = 1001;"'
+
+  - name: Verify CloudEvent envelope and content in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content:
+      - "specversion"
+      - "Sarah"
+      - '"iodebeziumop":"u"'

--- a/outbox/order-service/src/main/docker/Dockerfile.jvm
+++ b/outbox/order-service/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-21-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/outbox/pom.xml
+++ b/outbox/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.debezium-quarkus>2.4.0.Alpha2</version.debezium-quarkus>
     <version.quarkus>3.0.0.Final</version.quarkus>

--- a/outbox/shipment-service/src/main/docker/Dockerfile.jvm
+++ b/outbox/shipment-service/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-21-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <version.jackson>2.13.4</version.jackson>
         <version.kafka>3.9.0</version.kafka>
         <version.surfire-plugin>3.5.5</version.surfire-plugin>
+        <version.bytebuddy>1.14.18</version.bytebuddy>
 
         <!-- Common encoding defaults -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -48,6 +49,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.bytebuddy}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${version.bytebuddy}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>

--- a/scripts/run-example-test.py
+++ b/scripts/run-example-test.py
@@ -276,8 +276,14 @@ def step_kafka_consume(step, config):
     topic = step["topic"]
     timeout_seconds = step.get("timeout_seconds", 30)
     expected_content = step.get("expected_content")
-    if expected_content is not None and not isinstance(expected_content, str):
-        expected_content = str(expected_content)
+    
+    if expected_content is None:
+        expected_contents = []
+    elif isinstance(expected_content, list):
+        expected_contents = [str(item) for item in expected_content]
+    else:
+        expected_contents = [str(expected_content)]
+
     timeout_ms = timeout_seconds * 1000
     service = step.get("service", "kafka")
 
@@ -294,13 +300,26 @@ def step_kafka_consume(step, config):
     result = run_cmd(cmd, check=False, capture_output=True)
     output = result.stdout + result.stderr
 
-    if expected_content and expected_content not in output:
+    if not expected_contents:
+        return
+
+    # Split output into individual lines (each representing a single message)
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+
+    # Look for a single message containing all expected substrings
+    found = False
+    for line in lines:
+        if all(expected in line for expected in expected_contents):
+            found = True
+            break
+
+    expected_str = ", ".join(f"'{e}'" for e in expected_contents)
+    if not found:
         raise RuntimeError(
-            f"Expected '{expected_content}' not found in Kafka topic '{topic}'.\n"
+            f"Could not find any single message containing all expected substrings [{expected_str}] in Kafka topic '{topic}'.\n"
             f"Consumer output:\n{output[-2000:]}"
         )
-    if expected_content:
-        print(f"  -> Found '{expected_content}' in topic output (OK)")
+    print(f"  -> Found all expected substrings [{expected_str}] in a single message (OK)")
 
 
 def step_env_override(step, config):


### PR DESCRIPTION
## Description

Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the `cloudevents` example, utilizing the shared YAML-driven test runner established in #406.

### Changes
* **Debezium 3.5 API Updates**: Updated connector configurations (`register-postgres-json-json.json`, `register-postgres-json-avro.json`, `register-postgres-avro-avro.json`) to replace the deprecated/removed `database.server.name` with `topic.prefix`.
* **Quarkus 3.x / Java 21 Support**: Rewrote `avro-data-extractor/Dockerfile` to run on an Eclipse Temurin Java 21 base image and use the modern Quarkus `target/quarkus-app/` layout.
* **CloudEvents E2E Test Manifest**: Added `cloudevents/test.yaml` which defines the full test workflow:
  * Builds and starts all services via Docker Compose (PostgreSQL, Kafka, Connect, Schema Registry, Schema Registry UI, and `avro-extractor` Streams application).
  * Registers the `inventory-connector-json-json` connector configured with the CloudEvents Converter.
  * Modifies a customer's first name in the PostgreSQL source database.
  * Consumes the `dbserver1.inventory.customers` Kafka topic to verify that the CDC event is wrapped in a CloudEvents envelope (asserting on `specversion`) and contains the correct update.
* **CI Workflow**: Updated `.github/workflows/cloudevents.yml` to trigger on changes to the example or test runner, set up Python 3.11, install dependencies, and run the E2E test.

### Verification
* Verified compiling the `avro-data-extractor` Quarkus application.
* Tested and passed the E2E test execution locally using `python3 scripts/run-example-test.py cloudevents`.

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file