### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the json-logging example

### DIFF
--- a/.github/workflows/json-logging-workflow.yml
+++ b/.github/workflows/json-logging-workflow.yml
@@ -1,0 +1,30 @@
+name: Build [json-logging]
+
+on:
+  push:
+    paths:
+      - 'json-logging/**'
+      - '.github/workflows/json-logging-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'json-logging/**'
+      - '.github/workflows/json-logging-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run json-logging test
+        run: python scripts/run-example-test.py json-logging

--- a/json-logging/docker-compose.yaml
+++ b/json-logging/docker-compose.yaml
@@ -20,6 +20,11 @@ services:
      - MYSQL_ROOT_PASSWORD=debezium
      - MYSQL_USER=mysqluser
      - MYSQL_PASSWORD=mysqlpw
+    healthcheck:
+      test: "mysqladmin ping -uroot -pdebezium"
+      interval: 2s
+      timeout: 20s
+      retries: 10
 
   connect:
     build:
@@ -27,8 +32,10 @@ services:
     ports:
      - 8083:8083
     depends_on:
-     - kafka
-     - mysql
+      kafka:
+        condition: service_started
+      mysql:
+        condition: service_healthy
     environment:
      - BOOTSTRAP_SERVERS=kafka:9092
      - GROUP_ID=1

--- a/json-logging/test.yaml
+++ b/json-logging/test.yaml
@@ -1,0 +1,40 @@
+name: json-logging
+description: Tests Debezium MySQL connector logs with Logstash JSONEventLayout
+env_file: ../.env
+compose_file: docker-compose.yaml
+cleanup:
+  type: docker_compose_down
+  volumes: true
+steps:
+  - name: Build all images
+    type: docker_compose_build
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+  - name: Register MySQL connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: register-mysql.json
+    expected_status: [200, 201]
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+  - name: Trigger REST API error stacktrace log
+    type: http_wait
+    url: http://localhost:8083/error
+    expected_status: [404]
+    timeout_seconds: 10
+  - name: Verify JSON-formatted exception log in connect stdout
+    type: wait_for_log
+    service: connect
+    expected_content: '"message":"Uncaught exception in REST call to \/error"'
+    timeout_seconds: 20


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the json-logging example, utilizing the shared YAML-driven test runner established in #406.

Changes
- **E2E Test Manifest (`test.yaml`)**: Added a test manifest that:
  - Builds the custom Kafka Connect image enriched with the Logstash JSONEventLayout.
  - Starts all services (`mysql`, `kafka`, `connect`).
  - Registers the MySQL connector once the Connect API is ready.
  - Verifies the connector transitions to `RUNNING`.
  - Triggers a REST API error to force an unhandled exception stacktrace by querying `GET /error`.
  - Verifies that the logs are outputted in JSON format and contain the correct serialized JSON event message: `"message":"Uncaught exception in REST call to \/error"`.
- **Docker Compose Setup (`docker-compose.yaml`)**: Added a healthcheck to the `mysql` service using `mysqladmin ping` and configured the `connect` service to depend on `mysql` being healthy. This resolves a startup race condition where Connect tried to register the MySQL connector before the database was ready.
- **CI Workflow**: Added `.github/workflows/json-logging-workflow.yml` to trigger on changes to the example or test runner, set up Python 3.11, and run the test using `run-example-test.py`.

## Checklist
- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file