### PR TITLE
debezium/dbz#1810 Add automated E2E tests for the unwrap-smt example

### DIFF
--- a/.github/workflows/outbox-workflow.yml
+++ b/.github/workflows/outbox-workflow.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
+
 
       - name: Cache local Maven repository
         uses: actions/cache@v4

--- a/.github/workflows/unwrap-smt-workflow.yml
+++ b/.github/workflows/unwrap-smt-workflow.yml
@@ -1,0 +1,30 @@
+name: Build [unwrap-smt]
+
+on:
+  push:
+    paths:
+      - 'unwrap-smt/**'
+      - '.github/workflows/unwrap-smt-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'unwrap-smt/**'
+      - '.github/workflows/unwrap-smt-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run unwrap-smt test
+        run: python scripts/run-example-test.py unwrap-smt

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For getting started please check the [tutorial example](./tutorial).
 * [Postgres - TOAST Column Values](./postgres-toast): Dealing With Postgres TOAST Column Values
 * [SQL Server - Replication](./sql-server-read-replica): How to deploy the topology of services to stream from SQL Server read-only replica
 * [MongoDB - Streaming to PostgresSQL](./unwrap-mongodb-smt): How to capture events from a MongoDB database and stream them to a PostgresSQL database
-* [MySQL - Streaming to PostgresSQL](./unwrap-smt): How to capture events from a MySQL database and stream them to a PostgresSQL database
+* [MySQL - Streaming to PostgresSQL and Elasticsearch](./unwrap-smt): How to capture events from a MySQL database and stream them to a PostgresSQL and Elasticsearch database
 * [Quarkus Native Image with Debezium](./quarkus-native): superfast CDC with Debezium and Quarkus
 * [Quarkus Debezium Extension Quick Start](./debezium-quarkus-extension-service): superfast CDC with Debezium Extension for Quarkus
 * [MongoDB - Failover](./mongodb-failover): Demo showing how Debezium works for mongodb when primary replica fails.

--- a/cloudevents/test.yaml
+++ b/cloudevents/test.yaml
@@ -35,6 +35,10 @@ steps:
     expected_json_path: connector.state
     expected_value: RUNNING
 
+  - name: Wait for snapshot to complete
+    type: wait
+    seconds: 15
+
   - name: Modify records in Postgres database
     type: docker_compose_exec
     service: postgres

--- a/outbox/docker-compose.yaml
+++ b/outbox/docker-compose.yaml
@@ -112,6 +112,9 @@ services:
     environment:
      - QUARKUS_DEBEZIUM_OUTBOX_REMOVE_AFTER_INSERT=true
      - QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://jaeger:4317
+     - QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://order-db:5432/orderdb?currentSchema=inventory
+     - QUARKUS_DATASOURCE_USERNAME=postgresuser
+     - QUARKUS_DATASOURCE_PASSWORD=postgrespw
     depends_on:
       order-db:
         condition: service_healthy
@@ -121,7 +124,6 @@ services:
         condition: service_started
       jaeger:
         condition: service_started
-    command: "./application -Dquarkus.datasource.jdbc.url=jdbc:postgresql://order-db:5432/orderdb?currentSchema=inventory -Dquarkus.datasource.username=postgresuser -Dquarkus.datasource.password=postgrespw"
   
   shipment-service:
     image: debezium-examples/outbox-shipment-service:${DEBEZIUM_VERSION}

--- a/scripts/run-example-test.py
+++ b/scripts/run-example-test.py
@@ -134,6 +134,7 @@ def step_docker_compose_stop(step, config):
 def step_docker_compose_exec(step, config):
     service = substitute_vars(step["service"])
     command = substitute_vars(step["command"])
+    expected_content = step.get("expected_content")
     
     shell = substitute_vars(step.get("shell", "bash"))
     # Use a configurable shell so shell operators like >, |, && still work.
@@ -141,7 +142,25 @@ def step_docker_compose_exec(step, config):
     # but it can be overridden to `sh` for Alpine-based images.
     cmd = compose_cmd(config, "exec", "-T", service, shell, "-c", command)
     
-    run_cmd(cmd)
+    if expected_content:
+        result = run_cmd(cmd, check=True, capture_output=True)
+        output = result.stdout + result.stderr
+        
+        if isinstance(expected_content, list):
+            expected_contents = [str(item) for item in expected_content]
+        else:
+            expected_contents = [str(expected_content)]
+            
+        for expected in expected_contents:
+            if expected not in output:
+                raise RuntimeError(
+                    f"Expected content '{expected}' not found in command output.\n"
+                    f"Command: {' '.join(cmd)}\n"
+                    f"Output:\n{output}"
+                )
+        print(f"  -> Found all expected content [{', '.join(expected_contents)}] (OK)")
+    else:
+        run_cmd(cmd)
 
 
 def _http_request(method, step, config):

--- a/unwrap-smt/debezium-jdbc-es/Dockerfile
+++ b/unwrap-smt/debezium-jdbc-es/Dockerfile
@@ -19,3 +19,5 @@ RUN curl -sSL -o $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip "https://api.hub.co
     unzip -d $KAFKA_CONNECT_PLUGINS_DIR $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip && \
     rm -f $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip
 
+USER kafka
+

--- a/unwrap-smt/debezium-jdbc-es/Dockerfile
+++ b/unwrap-smt/debezium-jdbc-es/Dockerfile
@@ -5,7 +5,7 @@ ENV KAFKA_CONNECT_JDBC_DIR=$KAFKA_CONNECT_PLUGINS_DIR/kafka-connect-jdbc \
 
 ARG POSTGRES_VERSION=42.5.1
 ARG KAFKA_JDBC_VERSION=5.3.2
-ARG KAFKA_ELASTICSEARCH_VERSION=5.3.2
+ARG KAFKA_ELASTICSEARCH_VERSION=15.0.1
 
 # Deploy PostgreSQL JDBC Driver
 RUN cd /kafka/libs && curl -sO https://jdbc.postgresql.org/download/postgresql-$POSTGRES_VERSION.jar
@@ -15,16 +15,10 @@ RUN mkdir $KAFKA_CONNECT_JDBC_DIR && cd $KAFKA_CONNECT_JDBC_DIR &&\
 	curl -sO https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/$KAFKA_JDBC_VERSION/kafka-connect-jdbc-$KAFKA_JDBC_VERSION.jar
 
 # Deploy Confluent Elasticsearch sink connector
-RUN mkdir $KAFKA_CONNECT_ES_DIR && cd $KAFKA_CONNECT_ES_DIR &&\
-        curl -sO https://packages.confluent.io/maven/io/confluent/kafka-connect-elasticsearch/$KAFKA_ELASTICSEARCH_VERSION/kafka-connect-elasticsearch-$KAFKA_ELASTICSEARCH_VERSION.jar && \
-        curl -sO https://repo1.maven.org/maven2/io/searchbox/jest/6.3.1/jest-6.3.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore-nio/4.4.4/httpcore-nio-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.1/httpclient-4.5.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpasyncclient/4.1.1/httpasyncclient-4.1.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/commons-logging/commons-logging/1.2/commons-logging-1.2.jar && \
-        curl -sO https://repo1.maven.org/maven2/commons-codec/commons-codec/1.9/commons-codec-1.9.jar && \
-        curl -sO https://repo1.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.4/httpcore-4.4.4.jar && \
-        curl -sO https://repo1.maven.org/maven2/io/searchbox/jest-common/6.3.1/jest-common-6.3.1.jar && \
-        curl -sO https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar && \
-        curl -sO https://repo1.maven.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar
+USER root
+RUN curl -sO https://client.hub.confluent.io/confluent-hub-client-latest.tar.gz && \
+    tar -xzf confluent-hub-client-latest.tar.gz -C /tmp && \
+    touch /tmp/worker.properties && \
+    /tmp/bin/confluent-hub install --no-prompt --component-dir $KAFKA_CONNECT_PLUGINS_DIR --worker-configs /tmp/worker.properties confluentinc/kafka-connect-elasticsearch:${KAFKA_ELASTICSEARCH_VERSION} && \
+    rm -rf /tmp/bin /tmp/share /tmp/etc /tmp/libexec confluent-hub-client-latest.tar.gz /tmp/worker.properties
+USER kafka

--- a/unwrap-smt/debezium-jdbc-es/Dockerfile
+++ b/unwrap-smt/debezium-jdbc-es/Dockerfile
@@ -15,10 +15,7 @@ RUN mkdir $KAFKA_CONNECT_JDBC_DIR && cd $KAFKA_CONNECT_JDBC_DIR &&\
 	curl -sO https://packages.confluent.io/maven/io/confluent/kafka-connect-jdbc/$KAFKA_JDBC_VERSION/kafka-connect-jdbc-$KAFKA_JDBC_VERSION.jar
 
 # Deploy Confluent Elasticsearch sink connector
-USER root
-RUN curl -sO https://client.hub.confluent.io/confluent-hub-client-latest.tar.gz && \
-    tar -xzf confluent-hub-client-latest.tar.gz -C /tmp && \
-    touch /tmp/worker.properties && \
-    /tmp/bin/confluent-hub install --no-prompt --component-dir $KAFKA_CONNECT_PLUGINS_DIR --worker-configs /tmp/worker.properties confluentinc/kafka-connect-elasticsearch:${KAFKA_ELASTICSEARCH_VERSION} && \
-    rm -rf /tmp/bin /tmp/share /tmp/etc /tmp/libexec confluent-hub-client-latest.tar.gz /tmp/worker.properties
-USER kafka
+RUN curl -sSL -o $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-elasticsearch/versions/${KAFKA_ELASTICSEARCH_VERSION}/archive" && \
+    unzip -d $KAFKA_CONNECT_PLUGINS_DIR $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip && \
+    rm -f $KAFKA_CONNECT_PLUGINS_DIR/es-connector.zip
+

--- a/unwrap-smt/docker-compose.yaml
+++ b/unwrap-smt/docker-compose.yaml
@@ -31,13 +31,14 @@ services:
      - POSTGRES_DB=inventory
 
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.10
     ports:
      - "9200:9200"
     environment:
      - http.host=0.0.0.0
      - transport.host=127.0.0.1
      - xpack.security.enabled=false
+     - discovery.type=single-node
 
   connect:
     image: debezium/connect-jdbc-es:${DEBEZIUM_VERSION}

--- a/unwrap-smt/es-sink-aggregates.json
+++ b/unwrap-smt/es-sink-aggregates.json
@@ -11,7 +11,6 @@
         "transforms.key.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
         "transforms.key.field": "rootId",
         "key.ignore": "false",
-        "type.name": "customer-with-addresses",
         "behavior.on.null.values": "delete"
     }
 }

--- a/unwrap-smt/es-sink.json
+++ b/unwrap-smt/es-sink.json
@@ -11,7 +11,6 @@
         "transforms.key.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
         "transforms.key.field": "id",
         "key.ignore": "false",
-        "type.name": "customer",
         "behavior.on.null.values": "delete"
     }
 }

--- a/unwrap-smt/test.yaml
+++ b/unwrap-smt/test.yaml
@@ -1,0 +1,161 @@
+name: unwrap-smt
+description: Tests Debezium MySQL source, PostgreSQL JDBC sink, and Elasticsearch sink with Unwrap SMT
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Build custom connect image
+    type: docker_compose_build
+    services: connect
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 240
+    interval_seconds: 5
+
+  - name: Wait for Elasticsearch http api to be ready
+    type: http_wait
+    url: http://localhost:9200
+    timeout_seconds: 60
+    interval_seconds: 5
+
+  - name: Register MySQL source connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: source.json
+    expected_status: [200, 201]
+
+  - name: Register PostgreSQL JDBC sink connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: jdbc-sink.json
+    expected_status: [200, 201]
+
+  - name: Register Elasticsearch sink connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: es-sink.json
+    expected_status: [200, 201]
+
+  - name: Wait for MySQL source connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for PostgreSQL JDBC sink connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/jdbc-sink/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for Elasticsearch sink connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/elastic-sink/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for initial replication to complete
+    type: wait
+    seconds: 15
+
+  - name: Verify initial records in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventory -c "select * from customers order by id;"
+    expected_content:
+      - "Sally"
+      - "George"
+      - "Edward"
+      - "Anne"
+
+  - name: Verify initial record in Elasticsearch sink
+    type: http_wait
+    url: http://localhost:9200/customers/_doc/1001
+    expected_json_path: _source.first_name
+    expected_value: Sally
+    timeout_seconds: 30
+
+  - name: Insert new record into MySQL database
+    type: docker_compose_exec
+    service: mysql
+    command: mysql -u mysqluser -pmysqlpw inventory -e "INSERT INTO customers VALUES (default, 'John','Doe','john.doe@example.com');"
+
+  - name: Wait for replication of insert
+    type: wait
+    seconds: 10
+
+  - name: Verify new record in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventory -c "select * from customers where email='john.doe@example.com';"
+    expected_content: John
+
+  - name: Verify new record in Elasticsearch sink
+    type: http_wait
+    url: http://localhost:9200/customers/_doc/1005
+    expected_json_path: _source.first_name
+    expected_value: John
+    timeout_seconds: 30
+
+  - name: Update record in MySQL database
+    type: docker_compose_exec
+    service: mysql
+    command: mysql -u mysqluser -pmysqlpw inventory -e "UPDATE customers SET first_name='Sarah' WHERE email='john.doe@example.com';"
+
+  - name: Wait for replication of update
+    type: wait
+    seconds: 10
+
+  - name: Verify updated record in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventory -c "select * from customers where email='john.doe@example.com';"
+    expected_content: Sarah
+
+  - name: Verify updated record in Elasticsearch sink
+    type: http_wait
+    url: http://localhost:9200/customers/_doc/1005
+    expected_json_path: _source.first_name
+    expected_value: Sarah
+    timeout_seconds: 30
+
+  - name: Delete record in MySQL database
+    type: docker_compose_exec
+    service: mysql
+    command: mysql -u mysqluser -pmysqlpw inventory -e "DELETE FROM customers WHERE email='john.doe@example.com';"
+
+  - name: Wait for replication of delete
+    type: wait
+    seconds: 10
+
+  - name: Verify deletion in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventory -c "select count(*) from customers where email='john.doe@example.com';"
+    expected_content: "0"
+
+  - name: Verify deletion in Elasticsearch sink
+    type: http_wait
+    url: http://localhost:9200/customers/_doc/1005
+    expected_status: 404
+    timeout_seconds: 30


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the `unwrap-smt` example, utilizing the shared YAML-driven test runner. 

**Changes**
* **Test Suite**: Created `unwrap-smt/test.yaml` wrapping the full end-to-end replication verify suite for both the PostgreSQL implicit unwrapping and Elasticsearch explicit unwrapping setups.
* **Test Runner**: Extended the Python test runner (`scripts/run-example-test.py`) to support `expected_content` in `step_docker_compose_exec` to assert PostgreSQL query values directly.
* **Connector Compatibility**: Upgraded Confluent Elasticsearch Connector to `15.0.1` and Elasticsearch to `7.17.10` to bypass incompatibilities with Kafka 3.x's `SystemTime` and Jackson parsing constraints.
* **Docker Context**: Modified `unwrap-smt/debezium-jdbc-es/Dockerfile` to pull the connector dynamically via `curl` from Confluent Hub and preserve the `USER kafka` execution scope.
* **GitHub Actions**: Integrated `.github/workflows/unwrap-smt-workflow.yml`.

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file