### PR TITLE
debezium/dbz#1810 Add E2E test for unwrap-mongodb-smt example

### DIFF
--- a/.github/workflows/unwrap-mongodb-smt-workflow.yml
+++ b/.github/workflows/unwrap-mongodb-smt-workflow.yml
@@ -1,0 +1,30 @@
+name: Build [unwrap-mongodb-smt]
+
+on:
+  push:
+    paths:
+      - 'unwrap-mongodb-smt/**'
+      - '.github/workflows/unwrap-mongodb-smt-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'unwrap-mongodb-smt/**'
+      - '.github/workflows/unwrap-mongodb-smt-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run unwrap-mongodb-smt test
+        run: python scripts/run-example-test.py unwrap-mongodb-smt

--- a/unwrap-mongodb-smt/test.yaml
+++ b/unwrap-mongodb-smt/test.yaml
@@ -1,0 +1,124 @@
+name: unwrap-mongodb-smt
+description: Tests Debezium MongoDB source with Unwrap SMT and PostgreSQL JDBC sink
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Build custom connect image
+    type: docker_compose_build
+    services: connect
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 240
+    interval_seconds: 5
+
+  - name: Wait for Connect to fully initialize
+    type: wait
+    seconds: 30
+
+  - name: Register MongoDB source connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: mongodb-source.json
+    expected_status: [200, 201]
+
+  - name: Register PostgreSQL JDBC sink connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: jdbc-sink.json
+    expected_status: [200, 201]
+
+  - name: Wait for MongoDB source connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for PostgreSQL JDBC sink connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/jdbc-sink/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for initial replication to complete
+    type: wait
+    seconds: 15
+
+  - name: Verify initial records in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventorydb -c "select * from customers order by id;"
+    expected_content:
+      - "Sally"
+      - "George"
+      - "Edward"
+      - "Anne"
+
+  - name: Insert new record into MongoDB database
+    type: docker_compose_exec
+    service: mongodb
+    shell: sh
+    command: |
+      mongosh -u debezium -p dbz --authenticationDatabase admin inventory --eval "db.customers.insertOne({_id: NumberLong(1005), first_name: 'John', last_name: 'Doe', email: 'john.doe@example.com'})"
+
+  - name: Wait for replication of insert
+    type: wait
+    seconds: 10
+
+  - name: Verify new record in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventorydb -c "select * from customers where email='john.doe@example.com';"
+    expected_content: John
+
+  - name: Update record in MongoDB database
+    type: docker_compose_exec
+    service: mongodb
+    shell: sh
+    command: |
+      mongosh -u debezium -p dbz --authenticationDatabase admin inventory --eval 'db.customers.updateOne({_id: NumberLong(1005)}, {$set: {first_name: "Sarah"}})'
+
+  - name: Wait for replication of update
+    type: wait
+    seconds: 10
+
+  - name: Verify updated record in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventorydb -c "select * from customers where email='john.doe@example.com';"
+    expected_content: Sarah
+
+  - name: Delete record in MongoDB database
+    type: docker_compose_exec
+    service: mongodb
+    shell: sh
+    command: |
+      mongosh -u debezium -p dbz --authenticationDatabase admin inventory --eval "db.customers.deleteOne({_id: NumberLong(1005)})"
+
+  - name: Wait for replication of delete
+    type: wait
+    seconds: 10
+
+  - name: Verify deletion in PostgreSQL sink database
+    type: docker_compose_exec
+    service: postgres
+    command: psql -U postgresuser -d inventorydb -c "select count(*) from customers where email='john.doe@example.com';"
+    expected_content: "0"


### PR DESCRIPTION
## Description
Fixes debezium/dbz#1810

This PR introduces automated end-to-end testing for the `unwrap-mongodb-smt` example, validating Debezium's MongoDB Event Flattening SMT (`ExtractNewDocumentState`) and the PostgreSQL JDBC sink replication using the shared YAML-driven test runner.

### Changes
* **Test Suite:** Created `unwrap-mongodb-smt/test.yaml` to orchestrate and verify the replication flow:
  * Starts the base services including `mongodb`, replica set configuration initialization (`mongodb-init`), `postgres`, and `connect`.
  * Registers both the MongoDB CDC source connector and PostgreSQL JDBC sink connector.
  * Asserts the replication of initial data from MongoDB to PostgreSQL.
  * Mutates documents (performs `insertOne`, `updateOne`, and `deleteOne` commands via `mongosh`) and validates that the flattened states are correctly UPSERTed and deleted in the PostgreSQL target tables.
* **CI Integration:** Created `.github/workflows/unwrap-mongodb-smt-workflow.yml` to run the E2E suite on every push or PR affecting the example files or test runner.

## Checklist

- [x] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file