### PR TITLE
debezium/dbz#1810 Add E2E test for debezium-python example

### DIFF
--- a/.github/workflows/debezium-python-workflow.yml
+++ b/.github/workflows/debezium-python-workflow.yml
@@ -1,0 +1,44 @@
+name: Build [debezium-python]
+
+on:
+  push:
+    paths:
+      - 'debezium-python/**'
+      - '.github/workflows/debezium-python-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'debezium-python/**'
+      - '.github/workflows/debezium-python-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('debezium-python/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run debezium-python test
+        run: python scripts/run-example-test.py debezium-python

--- a/debezium-python/connect_mode_test.py
+++ b/debezium-python/connect_mode_test.py
@@ -16,18 +16,12 @@ This example:
 
 from pathlib import Path
 from testcontainers.postgres import PostgresContainer
-from testcontainers.core.waiting_utils import wait_for_logs
 
 # Import local Connect mode extensions
 from debezium_connect import DebeziumConnectEngine, BaseConnectChangeHandler
 from pydebeziumai import DebeziumEventModel, SourceRecordExtractor, print_record_info
 
 OFFSET_FILE = Path(__file__).parent.joinpath('connect-mode-offsets.dat')
-
-
-def wait_for_postgresql_to_start(self) -> None:
-    """Patch for testcontainers PostgreSQL startup detection."""
-    wait_for_logs(self, ".*PostgreSQL init process complete.*")
 
 
 class DbPostgresql:
@@ -45,7 +39,6 @@ class DbPostgresql:
                                                       driver=None)
                                     .with_exposed_ports(POSTGRES_PORT_DEFAULT)
                                     )
-    PostgresContainer._connect = wait_for_postgresql_to_start
 
     def start(self):
         print("Starting Postgresql Db...")
@@ -86,7 +79,7 @@ class ConnectModeHandler(BaseConnectChangeHandler):
 
     def __init__(self):
         self.event_count = 0
-        self.max_events = 5  # Stop after processing a few events
+        self.max_events = 4  # Stop after processing a few events
 
     def handleConnectBatch(self, records):
         """

--- a/debezium-python/test.yaml
+++ b/debezium-python/test.yaml
@@ -1,0 +1,16 @@
+name: debezium-python
+description: Tests Debezium Python Connect-mode embedded engine.
+
+steps:
+  - name: Install Python requirements
+    type: local_exec
+    command: pip install -r requirements.txt
+
+  - name: Setup Debezium JARs via Maven
+    type: local_exec
+    command: python3 setup_jars.py
+
+  - name: Run Connect-mode test
+    type: local_exec
+    command: python3 connect_mode_test.py
+    expected_content: "Test completed successfully!"


### PR DESCRIPTION
Fixes debezium/dbz#1810

## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
This PR adds automated End-to-End (E2E) testing for the `debezium-python` example, which demonstrates Debezium's Connect mode (zero JSON overhead, passing raw Java `SourceRecord` objects directly to Python via JPype).

Additionally, it resolves a blocker where the postgres container readiness wait check was hanging indefinitely on newer versions of `testcontainers`.

#### **Key Changes**
1. **Container Startup Fix (`debezium-python/connect_mode_test.py`)**: Removed the custom `wait_for_logs` override patch checking for `.*PostgreSQL init process complete.*` which was hanging. Allowing `testcontainers` to use its default connection-readiness wait strategy (`ExecWaitStrategy` executing `psql` directly inside the container) resolves the hang.
2. **E2E Test Definition (`debezium-python/test.yaml`)**: Created the test pipeline definition to install dependencies, run `setup_jars.py` to download Maven dependency JARs, and run `connect_mode_test.py` to verify the execution.
3. **GitHub Action Workflow (`.github/workflows/debezium-python-workflow.yml`)**: Added the automated CI workflow to trigger on code changes in the `debezium-python` example.
## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file



