### PR TITLE
debezium/dbz#2249 replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/debezium-server/debezium-server-mysql-redis-pubsub/docker-compose.yml
+++ b/debezium-server/debezium-server-mysql-redis-pubsub/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - MYSQL_PASSWORD=mysqlpw
 
   redis:
-    image: bitnami/redis:7.0
+    image: soldevelo/redis:7.0
     ports:
       - 6379:6379
     environment:


### PR DESCRIPTION
Closes debezium/dbz#2249

## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/redis:7.0` → [`soldevelo/redis:7.0`](https://hub.docker.com/r/soldevelo/redis)