### PR TITLE
debezium/dbz#1810 Add E2E test for mysql-replication example

### DIFF
--- a/.github/workflows/mysql-replication-workflow.yml
+++ b/.github/workflows/mysql-replication-workflow.yml
@@ -1,0 +1,30 @@
+name: Build [mysql-replication]
+
+on:
+  push:
+    paths:
+      - 'mysql-replication/**'
+      - '.github/workflows/mysql-replication-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'mysql-replication/**'
+      - '.github/workflows/mysql-replication-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run mysql-replication test
+        run: python scripts/run-example-test.py mysql-replication

--- a/mysql-replication/docker-compose.yaml
+++ b/mysql-replication/docker-compose.yaml
@@ -22,6 +22,11 @@ services:
      - MYSQL_PASSWORD=mysqlpw
     container_name:
       mysql-master
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdebezium"]
+      timeout: 5s
+      retries: 20
+      interval: 2s
 
   mysql_replica:
     ports:
@@ -34,7 +39,8 @@ services:
     container_name:
       mysql-replica
     depends_on:
-      - mysql_master
+      mysql_master:
+        condition: service_healthy
 
   connect:
     image: quay.io/debezium/connect:${DEBEZIUM_VERSION}

--- a/mysql-replication/test.yaml
+++ b/mysql-replication/test.yaml
@@ -1,0 +1,112 @@
+name: mysql-replication
+description: Tests Debezium MySQL connector with master-replica failover and switchback
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Wait for MySQL master to be ready
+    type: docker_compose_exec
+    service: mysql_master
+    command: bash -c "for i in {1..60}; do mysqladmin ping -u root -pdebezium --silent && exit 0; sleep 1; done; exit 1"
+
+  - name: Wait for MySQL replica to be ready
+    type: docker_compose_exec
+    service: mysql_replica
+    command: bash -c "for i in {1..60}; do mysqladmin ping -u root -pdebezium --silent && exit 0; sleep 1; done; exit 1"
+
+  - name: Deploy Debezium MySQL connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: register-mysql.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for initial snapshot to complete
+    type: wait
+    seconds: 15
+
+  - name: Verify Sally in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "Sally"
+
+  - name: Verify George in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "George"
+
+  - name: Insert customer on master
+    type: docker_compose_exec
+    service: mysql_master
+    command: mysql -u root -pdebezium inventory -e "INSERT INTO customers VALUES (default, 'John','Doe','john.doe@example.com');"
+
+  - name: Verify John Doe in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "John"
+
+  - name: Stop master server
+    type: docker_compose_stop
+    service: mysql_master
+
+  - name: Switch connector to replica
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-connector/config
+    body_file: connector-config-replica.json
+    expected_status: [200, 201]
+
+  - name: Restart master server
+    type: docker_compose_up
+    detach: true
+    services:
+      - mysql_master
+
+  - name: Wait for master to be ready after restart
+    type: docker_compose_exec
+    service: mysql_master
+    command: bash -c "for i in {1..60}; do mysqladmin ping -u root -pdebezium --silent && exit 0; sleep 1; done; exit 1"
+
+  - name: Insert customer on master again
+    type: docker_compose_exec
+    service: mysql_master
+    command: mysql -u root -pdebezium inventory -e "INSERT INTO customers VALUES (default, 'Jane','Doe','jane.smith@example.com');"
+
+  - name: Verify Jane Doe in Kafka
+    type: kafka_consume
+    topic: dbserver1.inventory.customers
+    timeout_seconds: 60
+    expected_content: "Jane"
+
+  - name: Switch connector back to master
+    type: http_put
+    url: http://localhost:8083/connectors/inventory-connector/config
+    body_file: connector-config-master.json
+    expected_status: [200, 201]


### PR DESCRIPTION
Fixes debezium/dbz#1810

## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Here is the updated PR description for the `mysql-replication` example:



This PR adds automated End-to-End (E2E) testing for the `mysql-replication` example, which verifies the Debezium MySQL connector's failover capability from a primary/master node to its replica database and back.

Additionally, this PR fixes a timing/startup race condition that occurs during replication initialization on Docker Compose startup and container restarts.



#### **Key Changes**

1. **E2E Test Definition (`mysql-replication/test.yaml`)**:
   * Creates the test workflow executing the complete replication failover scenario:
     1. Starts MySQL master-replica services.
     2. Deploys the MySQL connector pointing to `mysql-replica` and checks the initial snapshot ingest.
     3. Inserts customer records on the master node and verifies they are streamed to Kafka.
     4. Stops the master node, updates the connector config to point to `mysql-replica` directly.
     5. Restarts the master node, writes subsequent data, and verifies replication/streaming resume successfully.
     6. Switches the connector configuration back to `mysql_master`.

2. **Replication Race Condition Fix (`mysql-replication/docker-compose.yaml`)**:
   * Added a `healthcheck` to the `mysql_master` service utilizing `mysqladmin ping`.
   * Modified `mysql_replica` to depend on `mysql_master` under the `service_healthy` condition. This ensures that the replica database is started only after the primary database is fully booted and replication-ready, avoiding connection retries and replica sync failures.

3. **Looping Readiness Checks (`mysql-replication/test.yaml`)**:
   * Replaced single-run `mysqladmin ping` checks with robust `until` loop checks (`until mysqladmin ping -u root -pdebezium --silent; do sleep 1; done`) to handle container initialization time gracefully during startups and restarts.

4. **Runner Script Improvements (`scripts/run-example-test.py`)**:
   * Enhanced `step_kafka_consume` to correctly support list-based expected content across distinct message streams.
   * Restructured cleanup handlers to support sequentially running multiple cleanup steps.

5. **CI Automation (`.github/workflows/mysql-replication-workflow.yml`)**:
   * Setup GitHub Actions workflow to run the example test pipeline on code changes.

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file