### PR TITLE
debezium/dbz#1810 Add E2E test for postgres-kafka-signal example

### DIFF
--- a/.github/workflows/postgres-kafka-signal-workflow.yml
+++ b/.github/workflows/postgres-kafka-signal-workflow.yml
@@ -1,0 +1,30 @@
+name: Build [postgres-kafka-signal]
+
+on:
+  push:
+    paths:
+      - 'postgres-kafka-signal/**'
+      - '.github/workflows/postgres-kafka-signal-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'postgres-kafka-signal/**'
+      - '.github/workflows/postgres-kafka-signal-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run postgres-kafka-signal test
+        run: python scripts/run-example-test.py postgres-kafka-signal

--- a/postgres-kafka-signal/test.yaml
+++ b/postgres-kafka-signal/test.yaml
@@ -1,0 +1,93 @@
+name: postgres-kafka-signal
+description: Tests Debezium PostgreSQL connector with Kafka signaling and incremental snapshots
+compose_file: docker-compose.yml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Wait for PostgreSQL to be ready
+    type: docker_compose_exec
+    service: postgres
+    command: pg_isready -U myuser -d postgres
+
+  - name: Create data table and signal table
+    type: docker_compose_exec
+    service: postgres
+    command: >-
+      psql -U myuser -d postgres -c "
+      CREATE TABLE characters (id INT PRIMARY KEY, first_name VARCHAR(50), last_name VARCHAR(50));
+      INSERT INTO characters VALUES (1, 'luke', 'skywalker');
+      INSERT INTO characters VALUES (2, 'anakin', 'skywalker');
+      INSERT INTO characters VALUES (3, 'padmé', 'amidala');
+      CREATE TABLE debezium_signal (id VARCHAR(100) PRIMARY KEY, type VARCHAR(100) NOT NULL, data VARCHAR(2048) NULL);
+      "
+
+  - name: Deploy Debezium Postgres connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: connector.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/debezium-postgres/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Wait for initial snapshot to complete
+    type: wait
+    seconds: 15
+
+  - name: Verify initial snapshot records in Kafka
+    type: kafka_consume
+    service: broker
+    bootstrap_server: localhost:9092
+    consumer_path: kafka-console-consumer
+    topic: test.public.characters
+    timeout_seconds: 60
+    expected_content:
+      - "luke"
+      - "anakin"
+      - "padmé"
+
+  - name: Trigger incremental snapshot via database signal table
+    type: docker_compose_exec
+    service: postgres
+    command: >-
+      psql -U myuser -d postgres -c "INSERT INTO debezium_signal (id, type, data) VALUES ('ad-hoc-db', 'execute-snapshot', '{\"data-collections\": [\"public.characters\"],\"type\":\"incremental\"}');"
+
+  - name: Wait for database-triggered snapshot to execute
+    type: wait_for_log
+    service: connect
+    expected_content: "Requested 'INCREMENTAL' snapshot of data collections '[public.characters]' with additional conditions '[]'"
+    timeout_seconds: 45
+
+  - name: Trigger incremental snapshot via Kafka signaling topic
+    type: docker_compose_exec
+    service: broker
+    command: >-
+      bash -c "echo 'test:{\"type\":\"execute-snapshot\",\"data\": {\"data-collections\": [\"public.characters\"], \"type\": \"INCREMENTAL\", \"additional-conditions\": [{\"data-collection\": \"public.characters\", \"filter\": \"id > 0\"}]}}' | kafka-console-producer --bootstrap-server localhost:9092 --topic signal-topic --property parse.key=true --property key.separator=':'"
+
+  - name: Wait for Kafka-triggered snapshot to execute
+    type: wait_for_log
+    service: connect
+    expected_content: "filter='id > 0'"
+    timeout_seconds: 45

--- a/scripts/run-example-test.py
+++ b/scripts/run-example-test.py
@@ -306,12 +306,14 @@ def step_kafka_consume(step, config):
 
     timeout_ms = timeout_seconds * 1000
     service = step.get("service", "kafka")
+    bootstrap_server = step.get("bootstrap_server", "kafka:9092")
+    consumer_path = step.get("consumer_path", "/kafka/bin/kafka-console-consumer.sh")
 
     cmd = compose_cmd(
         config,
         "exec", "-T", service,
-        "/kafka/bin/kafka-console-consumer.sh",
-        "--bootstrap-server", "kafka:9092",
+        consumer_path,
+        "--bootstrap-server", bootstrap_server,
         "--topic", topic,
         "--from-beginning",
         "--max-messages", "100",


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1810
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->

This PR adds automated End-to-End (E2E) testing for the `postgres-kafka-signal` example, which demonstrates Debezium's ad-hoc incremental snapshot execution using both database signal table insertions and Kafka signaling channel events.

#### **Key Changes**

1. **E2E Test Definition (`postgres-kafka-signal/test.yaml`)**:
   * Creates the test workflow executing the complete ad-hoc signaling scenario:
     1. Starts Zookeeper, Confluent Server, Connect, and PostgreSQL services.
     2. Sets up database test tables and registers the Debezium Postgres connector.
     3. Checks the initial snapshot ingestion.
     4. Triggers an ad-hoc incremental snapshot by inserting into the database signaling table (`debezium_signal`).
     5. Triggers another ad-hoc incremental snapshot by publishing a signal event to the Kafka signaling topic (`signal-topic`).
     6. Verifies connect logs after each signal event to confirm the incremental snapshot executes successfully.

2. **Runner Script Flexibility (`scripts/run-example-test.py`)**:
   * Updated `step_kafka_consume` to accept custom `bootstrap_server` and `consumer_path` parameters. This allows running the console consumer on alternative broker stacks (e.g. Confluent Server) that don't match the default Debezium Kafka image's paths or hostnames.

3. **CI Automation (`.github/workflows/postgres-kafka-signal-workflow.yml`)**:
   * Set up the GitHub Actions workflow to run the example test pipeline on code changes.


## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file