### PR TITLE
debezium/dbz#1810 Add E2E test for http-signaling-notification example

### DIFF
--- a/.github/workflows/http-signaling-notification-workflow.yml
+++ b/.github/workflows/http-signaling-notification-workflow.yml
@@ -1,0 +1,36 @@
+name: Build [http-signaling-notification]
+
+on:
+  push:
+    paths:
+      - 'http-signaling-notification/**'
+      - '.github/workflows/http-signaling-notification-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'http-signaling-notification/**'
+      - '.github/workflows/http-signaling-notification-workflow.yml'
+      - 'scripts/run-example-test.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run http-signaling-notification test
+        run: python scripts/run-example-test.py http-signaling-notification

--- a/http-signaling-notification/initializerJson.json
+++ b/http-signaling-notification/initializerJson.json
@@ -11,5 +11,25 @@
       "body": "{\"id\":\"924e3ff8-2245-43ca-ba77-2af9af02fa07\",\"type\":\"log\",\"data\":{\"message\": \"Signal message received from http endpoint.\"}}",
       "statusCode": 200
     }
+  },
+  {
+    "httpRequest" : {
+      "method" : "POST",
+      "path" : "/developers/postbin/api/bin"
+    },
+    "httpResponse" : {
+      "body": "{\"binId\":\"mock-bin-id\",\"now\":1688742588470,\"expires\":1688744388470}",
+      "statusCode": 201
+    }
+  },
+  {
+    "httpRequest" : {
+      "method" : "POST",
+      "path" : "/developers/postbin/mock-bin-id"
+    },
+    "httpResponse" : {
+      "body": "ok",
+      "statusCode": 200
+    }
   }
 ]

--- a/http-signaling-notification/src/main/java/io/debezium/examples/notification/HttpNotificationChannel.java
+++ b/http-signaling-notification/src/main/java/io/debezium/examples/notification/HttpNotificationChannel.java
@@ -47,7 +47,7 @@ public class HttpNotificationChannel implements NotificationChannel {
         // Create a bin on the server
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(new URI("https://www.toptal.com/developers/postbin/api/bin"))
+                    .uri(new URI("http://mockServer:1080/developers/postbin/api/bin"))
                     .POST(HttpRequest.BodyPublishers.ofString(" "))
                     .build();
 
@@ -71,7 +71,7 @@ public class HttpNotificationChannel implements NotificationChannel {
             ObjectMapper mapper = new ObjectMapper();
             String notificationString = mapper.writeValueAsString(notification);
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(new URI("https://www.toptal.com/developers/postbin/" + binId))
+                    .uri(new URI("http://mockServer:1080/developers/postbin/" + binId))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(notificationString))
                     .build();

--- a/http-signaling-notification/test.yaml
+++ b/http-signaling-notification/test.yaml
@@ -1,0 +1,53 @@
+name: http-signaling-notification
+description: Tests Debezium custom HTTP signaling and notification channels
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Compile custom Java channels
+    type: local_exec
+    command: mvn clean package -DskipTests
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Deploy Debezium Postgres connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: register-postgres.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Verify custom HTTP signal reception in Connect logs
+    type: wait_for_log
+    service: connect
+    expected_content: "Recorded signal event"
+    timeout_seconds: 60
+
+  - name: Verify custom HTTP notification dispatch in Connect logs
+    type: wait_for_log
+    service: connect
+    expected_content: "Sending notification to http channel"
+    timeout_seconds: 60


### PR DESCRIPTION
## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
This PR adds automated End-to-End (E2E) testing for the `http-signaling-notification` example, which demonstrates Debezium's custom HTTP signaling and notification channels.

## Key Changes
1. **E2E Test Definition (`http-signaling-notification/test.yaml`)**:
   * Compiles custom Java channel classes (`HttpSignalChannel` & `HttpNotificationChannel`).
   * Starts PostgreSQL, Kafka, MockServer, and Kafka Connect services.
   * Deploys the PostgreSQL connector configured with `signal.enabled.channels=http` and `notification.enabled.channels=http`.
   * Asserts log entries verifying that the HTTP signal channel successfully fetched and recorded signal payloads from MockServer (`Recorded signal event`).
   * Asserts log entries verifying that notifications were dispatched to the custom HTTP channel (`Sending notification to http channel`).

2. **Mock Server Configuration (`initializerJson.json` & `HttpNotificationChannel.java`)**:
   * Configured mock responses for bin creation and postbin notification dispatches to point to the containerized `mockServer:1080` endpoint.

3. **CI Automation (`.github/workflows/http-signaling-notification-workflow.yml`)**:
   * Setup GitHub Actions workflow to run the example test pipeline on code changes.
## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file