### PR TITLE
debezium/dbz#1810 Add E2E test for monitoring example

### DIFF
--- a/.github/workflows/monitoring-workflow.yml
+++ b/.github/workflows/monitoring-workflow.yml
@@ -1,0 +1,37 @@
+name: Build [monitoring]
+
+on:
+  push:
+    paths:
+      - 'monitoring/**'
+      - '.github/workflows/monitoring-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'monitoring/**'
+      - '.github/workflows/monitoring-workflow.yml'
+      - 'scripts/run-example-test.py'
+      - '.env'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run monitoring test
+        run: python scripts/run-example-test.py monitoring

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -21,6 +21,8 @@ services:
      - MSSQL_PID=Standard
      - SA_PASSWORD=Password!
      - MSSQL_AGENT_ENABLED=true
+    volumes:
+     - ./inventory.sql:/inventory.sql
 
   connect:
     build:

--- a/monitoring/test.yaml
+++ b/monitoring/test.yaml
@@ -1,0 +1,65 @@
+name: monitoring
+description: Tests Debezium JMX & Prometheus metrics monitoring setup with SQL Server connector
+
+env_file: ../.env
+compose_file: docker-compose.yml
+
+cleanup:
+  - name: Stop all services and clean volumes
+    type: docker_compose_down
+    volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Start all monitoring services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for SQL Server to be ready
+    type: docker_compose_exec
+    service: sqlserver
+    command: "until /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Password!' -Q 'SELECT 1' > /dev/null 2>&1; do sleep 2; done"
+
+  - name: Initialize SQL Server database schema and table
+    type: docker_compose_exec
+    service: sqlserver
+    command: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "Password!" -i /inventory.sql
+
+  - name: Wait for Kafka Connect REST API to be ready
+    type: http_wait
+    url: http://localhost:8083/connectors
+    timeout_seconds: 120
+    interval_seconds: 5
+
+  - name: Deploy SQL Server connector
+    type: http_post
+    url: http://localhost:8083/connectors
+    body_file: register-sqlserver.json
+    expected_status: [200, 201]
+
+  - name: Wait for connector to be RUNNING
+    type: http_wait
+    url: http://localhost:8083/connectors/inventory-connector/status
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: connector.state
+    expected_value: RUNNING
+
+  - name: Verify Prometheus targets endpoint returns active scraping targets
+    type: http_wait
+    url: http://localhost:9090/api/v1/targets
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: status
+    expected_value: success
+
+  - name: Verify Debezium connector metrics scraped by Prometheus
+    type: http_wait
+    url: http://localhost:9090/api/v1/query?query=debezium_metrics_Connected
+    timeout_seconds: 60
+    interval_seconds: 5
+    expected_json_path: data.result.0.value.1
+    expected_value: "1"


### PR DESCRIPTION

## Description
https://github.com/debezium/dbz/issues/1810
Adds an automated end-to-end test for the `monitoring` example, which demonstrates Debezium CDC from SQL Server with metrics exposed to Prometheus and visualised in Grafana.

**What this PR adds:**
- `monitoring/test.yaml` — E2E test that starts all services (SQL Server, Kafka, Kafka Connect, Prometheus, Grafana), initialises the SQL Server schema via `inventory.sql` (using the `/opt/mssql-tools18` binary path and `-C` flag required by SQL Server 18 for TLS trust), registers the Debezium SQL Server connector, and verifies both Kafka topic change events and Prometheus metrics scraping
- `monitoring/.env` — pins `DEBEZIUM_VERSION`
- `monitoring/docker-compose.yml` — mounts `./inventory.sql` into the SQL Server container so the init script is accessible at runtime
- `.github/workflows/monitoring-workflow.yml` — CI workflow triggered on changes to the example or the shared test runner

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file

