### PR TITLE
debezium/dbz#1810 Add E2E test for debezium-server-name-mapper example

### DIFF
--- a/.github/workflows/debezium-server-name-mapper-workflow.yml
+++ b/.github/workflows/debezium-server-name-mapper-workflow.yml
@@ -5,28 +5,33 @@ on:
     paths:
       - 'debezium-server-name-mapper/**'
       - '.github/workflows/debezium-server-name-mapper-workflow.yml'
+      - 'scripts/run-example-test.py'
   pull_request:
     paths:
       - 'debezium-server-name-mapper/**'
       - '.github/workflows/debezium-server-name-mapper-workflow.yml'
       - '.env'
+      - 'scripts/run-example-test.py'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 21
+
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
           distribution: 'temurin'
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
+          java-version: '21'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('debezium-server-name-mapper/**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Check changes in [debezium-server-name-mapper] example
-        run: cd debezium-server-name-mapper && mvn clean install -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run debezium-server-name-mapper test
+        run: python scripts/run-example-test.py debezium-server-name-mapper

--- a/debezium-server-name-mapper/test.yaml
+++ b/debezium-server-name-mapper/test.yaml
@@ -1,0 +1,62 @@
+name: debezium-server-name-mapper
+description: Tests Debezium Server custom topic name mapper with Pulsar sink
+
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  - name: Stop the Quarkus Debezium Server background process
+    type: local_exec
+    command: pkill -f "[q]uarkus-run.jar" || true
+
+  - name: Remove stale offsets file
+    type: local_exec
+    command: rm -f target/offsets.dat
+
+  - name: Stop containers and clean volumes
+    type: docker_compose_down
+    volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Build the debezium-server-name-mapper project
+    type: local_exec
+    command: mvn package -DskipTests -B
+
+  - name: Start Postgres and Pulsar services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for Postgres to be ready
+    type: docker_compose_exec
+    service: db
+    command: "until pg_isready -U postgres -d postgres; do sleep 1; done"
+
+  - name: Wait for Pulsar to be ready
+    type: wait
+    seconds: 15
+
+  - name: Remove stale offsets file
+    type: local_exec
+    command: rm -f target/offsets.dat
+
+  - name: Run Debezium Server application in the background
+    type: local_exec
+    command: java -jar target/quarkus-app/quarkus-run.jar > app.log 2>&1 &
+
+  - name: Wait for Debezium Server initialization and snapshot
+    type: wait
+    seconds: 45
+
+  - name: Verify custom prefix topic creation in Pulsar broker stats
+    type: docker_compose_exec
+    service: pulsar
+    command: bin/pulsar-admin topics list public/default
+    expected_content: "superprefix.tutorial.inventory.customers"
+
+  - name: Stop Debezium Server background process
+    type: local_exec
+    command: pkill -f "[q]uarkus-run.jar" || true


### PR DESCRIPTION


## Description
https://github.com/debezium/dbz/issues/1810
Adds an automated end-to-end test for the `debezium-server-name-mapper` example, which demonstrates a custom `DebeziumTopicNameMapper` SPI implementation that applies a configurable prefix to all Pulsar topic names produced by Debezium Server.

**What this PR adds:**
- `debezium-server-name-mapper/test.yaml` — E2E test that builds the custom SPI JAR via Maven, starts Postgres and Pulsar, clears stale offset state (`target/offsets.dat`) to ensure a fresh snapshot on every run, launches Debezium Server in the background, and verifies the custom-prefixed topic `superprefix.tutorial.inventory.customers` is created in Pulsar's `public/default` namespace
- `debezium-server-name-mapper/.env` — pins `DEBEZIUM_VERSION` for reproducible builds
- `.github/workflows/debezium-server-name-mapper-workflow.yml` — CI workflow triggered on changes to the example or the shared test runner

## Checklist

- [X] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file

