### PR TITLE
debezium/dbz#1611 Add example for debezium-quarkus-hibernate-cache ex…

### DIFF
--- a/.github/workflows/debezium-quarkus-hibernate-cache-workflow.yml
+++ b/.github/workflows/debezium-quarkus-hibernate-cache-workflow.yml
@@ -1,0 +1,45 @@
+name: Build [debezium-quarkus-hibernate-cache]
+
+on:
+  push:
+    paths:
+      - 'debezium-quarkus-hibernate-cache/**'
+      - '.github/workflows/debezium-quarkus-hibernate-cache-workflow.yml'
+      - 'scripts/run-example-test.py'
+  pull_request:
+    paths:
+      - 'debezium-quarkus-hibernate-cache/**'
+      - '.github/workflows/debezium-quarkus-hibernate-cache-workflow.yml'
+      - 'scripts/run-example-test.py'
+      - '.env'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('debezium-quarkus-hibernate-cache/**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install pyyaml requests
+
+      - name: Run debezium-quarkus-hibernate-cache test
+        run: python scripts/run-example-test.py debezium-quarkus-hibernate-cache

--- a/debezium-quarkus-hibernate-cache/README.md
+++ b/debezium-quarkus-hibernate-cache/README.md
@@ -1,0 +1,59 @@
+# Debezium Quarkus Hibernate Second-Level Cache Invalidation
+
+This example demonstrates how to use the official **`debezium-quarkus-hibernate-cache`** extension to automatically invalidate items in the Hibernate Second-Level Cache (L2C) when external data changes occur in PostgreSQL (e.g. via direct SQL updates or external services bypassing Hibernate ORM).
+
+## Architecture & How It Works
+
+1. **Automatic Metamodel Discovery:** The extension scans the JPA metamodel at application startup to identify `@Cacheable` entities.
+2. **Built-in CDC Capture:** The extension's internal `@Capturing` handler listens for Debezium Change Data Capture (CDC) events streamed from the PostgreSQL Write-Ahead Log (WAL).
+3. **Automated L2C Eviction:** When an entity is updated or deleted in the database, the extension automatically evicts the corresponding entity from Hibernate's L2 Cache without requiring any custom Java eviction code in your application.
+
+## Prerequisites
+
+- JDK 21+
+- Apache Maven 3.9+
+- Docker & Docker Compose
+
+## Quick Start
+
+### 1. Build and Start Services
+
+```bash
+mvn clean package -DskipTests
+docker compose up -d --build
+```
+
+### 2. Manual Testing
+
+1. Query an item using HTTP GET (loads `Notebook` into the L2 Cache):
+   ```bash
+   curl http://localhost:8080/items/1
+   ```
+   Response:
+   ```json
+   {"id":1,"name":"Notebook","price":10.99}
+   ```
+
+2. Update the item price directly in PostgreSQL via `psql` (bypassing Hibernate ORM):
+   ```bash
+   docker compose exec postgres psql -U postgres -d inventory -c "UPDATE inventory.item SET price = 15.99 WHERE id = 1;"
+   ```
+
+3. Debezium's `@Capturing` handler captures the WAL update event and automatically evicts `Item` #1 from the L2 Cache.
+
+4. Query the item again to observe the updated price:
+   ```bash
+   curl http://localhost:8080/items/1
+   ```
+   Response:
+   ```json
+   {"id":1,"name":"Notebook","price":15.99}
+   ```
+
+### 3. Running Automated E2E Tests
+
+To run the automated E2E test runner:
+
+```bash
+python scripts/run-example-test.py debezium-quarkus-hibernate-cache
+```

--- a/debezium-quarkus-hibernate-cache/docker-compose.yaml
+++ b/debezium-quarkus-hibernate-cache/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: quay.io/debezium/example-postgres:${DEBEZIUM_VERSION:-latest}
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 20s
+      retries: 10
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=inventory
+      - PGPASSWORD=postgres
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/z_init.sql
+
+  item-service:
+    image: debezium-examples/debezium-quarkus-hibernate-cache:${DEBEZIUM_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: src/main/docker/Dockerfile.jvm
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_HOST=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=inventory
+      - QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/inventory
+      - DEBEZIUM_SOURCE_DATABASE_HOSTNAME=postgres
+      - DEBEZIUM_SOURCE_DATABASE_USER=postgres
+      - DEBEZIUM_SOURCE_DATABASE_PASSWORD=postgres
+      - DEBEZIUM_SOURCE_DATABASE_DBNAME=inventory

--- a/debezium-quarkus-hibernate-cache/init.sql
+++ b/debezium-quarkus-hibernate-cache/init.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS inventory;
+
+CREATE TABLE inventory.item (
+    id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    price DECIMAL(10, 2) NOT NULL
+);
+
+ALTER TABLE inventory.item REPLICA IDENTITY FULL;
+
+INSERT INTO inventory.item (id, name, price) VALUES (1, 'Notebook', 10.99);
+INSERT INTO inventory.item (id, name, price) VALUES (2, 'Wireless Mouse', 25.50);

--- a/debezium-quarkus-hibernate-cache/pom.xml
+++ b/debezium-quarkus-hibernate-cache/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.debezium.examples</groupId>
+        <artifactId>debezium-examples-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.acme</groupId>
+    <artifactId>debezium-quarkus-hibernate-cache-example</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-quarkus-hibernate-cache</artifactId>
+            <version>${version.debezium}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium.quarkus</groupId>
+            <artifactId>debezium-quarkus-postgres</artifactId>
+            <version>${version.debezium}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${version.quarkus}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>native-image-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.maven.compiler}</version>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/debezium-quarkus-hibernate-cache/src/main/docker/Dockerfile.jvm
+++ b/debezium-quarkus-hibernate-cache/src/main/docker/Dockerfile.jvm
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.21
+
+ENV LANGUAGE='en_US:en'
+
+COPY --chown=185 target/quarkus-app/ /deployments/
+
+EXPOSE 8080
+USER 185
+
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/debezium-quarkus-hibernate-cache/src/main/java/org/acme/Item.java
+++ b/debezium-quarkus-hibernate-cache/src/main/java/org/acme/Item.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import java.math.BigDecimal;
+import jakarta.persistence.Cacheable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Cacheable
+@Table(name = "item", schema = "inventory")
+public class Item {
+
+    @Id
+    public Long id;
+
+    public String name;
+
+    public BigDecimal price;
+
+    public Item() {
+    }
+
+    public Item(Long id, String name, BigDecimal price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+}

--- a/debezium-quarkus-hibernate-cache/src/main/java/org/acme/ItemResource.java
+++ b/debezium-quarkus-hibernate-cache/src/main/java/org/acme/ItemResource.java
@@ -1,0 +1,46 @@
+package org.acme;
+
+import java.util.HashMap;
+import java.util.Map;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.hibernate.Session;
+import org.hibernate.stat.Statistics;
+
+@Path("/items")
+@Produces(MediaType.APPLICATION_JSON)
+public class ItemResource {
+
+    @Inject
+    EntityManager entityManager;
+
+    @GET
+    @Path("/{id}")
+    public Response getItem(@PathParam("id") Long id) {
+        Item item = entityManager.find(Item.class, id);
+        if (item == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        // Detach to ensure subsequent queries query L2 cache / DB rather than entity manager L1 context
+        entityManager.detach(item);
+        return Response.ok(item).build();
+    }
+
+    @GET
+    @Path("/cache-stats")
+    public Map<String, Object> getCacheStats() {
+        Statistics stats = entityManager.unwrap(Session.class).getSessionFactory().getStatistics();
+        Map<String, Object> result = new HashMap<>();
+        result.put("hitCount", stats.getSecondLevelCacheHitCount());
+        result.put("missCount", stats.getSecondLevelCacheMissCount());
+        result.put("putCount", stats.getSecondLevelCachePutCount());
+        return result;
+    }
+}

--- a/debezium-quarkus-hibernate-cache/src/main/resources/application.properties
+++ b/debezium-quarkus-hibernate-cache/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+# Quarkus HTTP Port
+quarkus.http.port=8080
+
+# Datasource Configuration
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.username=${POSTGRES_USER:postgres}
+quarkus.datasource.password=${POSTGRES_PASSWORD:postgres}
+quarkus.datasource.jdbc.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:5432/${POSTGRES_DB:inventory}
+
+# Hibernate ORM & Second-Level Cache
+quarkus.hibernate-orm.database.default-schema=inventory
+quarkus.hibernate-orm.schema-management.strategy=validate
+quarkus.hibernate-orm.second-level-caching-enabled=true
+quarkus.hibernate-orm.metrics.enabled=true
+
+# Debezium Engine source connector properties
+debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
+debezium.source.database.hostname=${POSTGRES_HOST:localhost}
+debezium.source.database.port=5432
+debezium.source.database.user=${POSTGRES_USER:postgres}
+debezium.source.database.password=${POSTGRES_PASSWORD:postgres}
+debezium.source.database.dbname=${POSTGRES_DB:inventory}
+debezium.source.topic.prefix=tutorial
+debezium.source.table.include.list=inventory.item
+debezium.source.plugin.name=pgoutput
+debezium.source.schema.history.internal=io.debezium.relational.history.MemorySchemaHistory
+debezium.source.offset.storage=org.apache.kafka.connect.storage.MemoryOffsetBackingStore

--- a/debezium-quarkus-hibernate-cache/test.yaml
+++ b/debezium-quarkus-hibernate-cache/test.yaml
@@ -1,0 +1,54 @@
+name: debezium-quarkus-hibernate-cache
+description: Tests Debezium Quarkus Hibernate Second-Level Cache invalidation extension
+env_file: ../.env
+compose_file: docker-compose.yaml
+
+cleanup:
+  type: docker_compose_down
+  volumes: true
+
+steps:
+  - name: Ensure clean state before starting
+    type: docker_compose_down
+    volumes: true
+
+  - name: Compile application jar
+    type: local_exec
+    command: mvn clean package -DskipTests
+
+  - name: Build all Docker images
+    type: docker_compose_build
+
+  - name: Start all services
+    type: docker_compose_up
+    detach: true
+
+  - name: Wait for item-service to be ready
+    type: http_wait
+    url: http://localhost:8080/items/1
+    timeout_seconds: 120
+    interval_seconds: 5
+    expected_status: 200
+    expected_json_path: name
+    expected_value: Notebook
+
+  - name: Fetch Item 1 to populate L2 Cache
+    type: http_wait
+    url: http://localhost:8080/items/1
+    expected_status: 200
+    expected_json_path: price
+    expected_value: 10.99
+
+  - name: Update item price directly in database (bypassing Hibernate ORM)
+    type: docker_compose_exec
+    service: postgres
+    command: "psql -U postgres -d inventory -c \"UPDATE inventory.item SET price = 15.99 WHERE id = 1;\""
+
+  - name: Wait for Debezium CDC event to trigger L2 Cache eviction
+    type: http_wait
+    url: http://localhost:8080/items/1
+    timeout_seconds: 60
+    interval_seconds: 2
+    expected_status: 200
+    expected_json_path: price
+    expected_value: 15.99


### PR DESCRIPTION
…tension

## Description
<!--
Thanks a lot for taking time to contribute to Debezium <3!

Please provide a description of what your PR does. It is really helpful for people who would review your code.
-->
Fixes [debezium/dbz#1611](https://github.com/debezium/dbz/issues/1611)

This PR introduces a new example module `debezium-quarkus-hibernate-cache` demonstrating the official `debezium-quarkus-hibernate-cache` Quarkus extension for automatic Hibernate Second-Level Cache (L2C) invalidation upon receiving Debezium CDC events.

### Key Details
- **Architecture**: A Quarkus application using an embedded Debezium PostgreSQL connector alongside Hibernate ORM with `@Cacheable` JPA entities.
- **Zero Boilerplate**: Demonstrates how the extension automatically intercepts CDC events and invalidates stale L2C entries without requiring any custom Java listener or callback code.
- **E2E Test Definition**: Added `test.yaml` verifying that direct SQL updates (bypassing Hibernate) automatically evict the entity from L2C when Debezium processes the change event.
- **CI Workflow**: Added `.github/workflows/debezium-quarkus-hibernate-cache-workflow.yml` with standard path filters.

### Verification
Ran the automated E2E test suite locally:
```bash
python3 scripts/run-example-test.py debezium-quarkus-hibernate-cache
```
## Checklist

- [x] If the changes include a new example, I added it to the list of examples in the [README.md](https://github.com/debezium/debezium-examples/blob/main/README.md) file